### PR TITLE
Add Support For Windows Integration

### DIFF
--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-has_docker=$(command -v docker > /dev/null 2>&1)
+has_docker=$(command -v docker 2> /dev/null 1>&1)
 
 if [ "$(uname)" = "Linux" ]; then
     if [ -n "$WSL_DISTRO_NAME" ]; then
@@ -23,12 +23,12 @@ install_centos() {
 }
 
 # Debian/Ubuntu/Raspbian
-install_debian() {
+install_debian_ubuntu() {
     sudo apt update
     sudo apt install -y ca-certificates curl lsb-release
     sudo install -m 0755 -d /etc/apt/keyrings
     sudo curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg -o /etc/apt/keyrings/docker.asc
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt update
     sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo systemctl start docker
@@ -89,7 +89,7 @@ if [ ! "$has_docker" ]; then
             install_centos
             ;;
         debian | ubuntu | raspbian)
-            install_debian
+            install_debian_ubuntu
             ;;
         fedora)
             install_fedora

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -5,7 +5,7 @@ has_docker=$(command -v docker > /dev/null 2>&1)
 if [ "$(uname)" = "Linux" ]; then
     if [ -n "$WSL_DISTRO_NAME" ]; then
         OS="wsl"
-        has_docker=$(where.exe docker > /dev/null 2>&1)
+        has_docker="$(where.exe docker 2> /dev/null >&1)"
     else
         OS=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
     fi
@@ -60,17 +60,21 @@ install_arch() {
     sudo systemctl enable docker
 }
 
+# macOS
 install_darwin() {
     brew install --cask docker
     echo "\nLaunching Docker Desktop in order to start the Docker Engine..."
+    echo "Make sure Docker Engine is fully running before proceeding..."
     open -a Docker
 }
 
+# Windows WSL
 install_wsl() {
-    if [ -e $(which winget.exe > /dev/null 2>&1) ]; then
+    if [ -e "$(which winget.exe 2> /dev/null)" ]; then
         winget.exe install -e --id Docker.DockerDesktop
-        echo "\nLaunching Docker Desktop in order to start the Docker Engine..."
         $("/mnt/c/Program Files/Docker/Docker/Docker Desktop.exe")
+        echo "\nLaunching Docker Desktop in order to start the Docker Engine..."
+        echo "Make sure Docker Engine is fully running before proceeding..."
     else
         echo "Winget Package Manager is not found. Make sure Winget is installed before trying again."
         echo "\nDocker is not installed.".
@@ -79,7 +83,7 @@ install_wsl() {
 }
 
 # -----[ Main ]----------------------------------------------------------
-if [ ! $has_docker ]; then
+if [ ! "$has_docker" ]; then
     case $OS in
         centos | rhel)
             install_centos
@@ -107,11 +111,11 @@ if [ ! $has_docker ]; then
             exit 1
             ;;
     esac
-    if [ $(uname) = 'Linux' ]; then
+    if [ "$(uname)" = 'Linux' ]; then
         sudo usermod -aG docker "$(whoami)"
     fi
     echo
-    echo "Docker have been installed successfully."
+    echo "Docker has been installed successfully."
 else
-    echo "Docker already exist."
+    echo "Docker is already installed."
 fi

--- a/scripts/docker-uninstall.sh
+++ b/scripts/docker-uninstall.sh
@@ -5,7 +5,7 @@ has_docker=$(command -v docker > /dev/null 2>&1)
 if [ "$(uname)" = "Linux" ]; then
     if [ -n "$WSL_DISTRO_NAME" ]; then
         OS="wsl"
-        has_docker=$(where.exe docker > /dev/null 2>&1)
+        has_docker="$(where.exe docker 2> /dev/null >&1)"
     else
         OS=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
     fi
@@ -43,18 +43,13 @@ remove_darwin() {
 }
 
 remove_wsl() {
-    echo "Uninstalling Docker via Winget is currently not supported as the installer gets stuck. Use the standard Windows uninstall method."
-
-    if where.exe docker > /dev/null 2>&1; then
-        echo "\nDocker is still installed."
-    else
-        echo "\nDocker wasn't installed."
-    fi
+    echo "Uninstalling Docker via Winget is currently not supported as the uninstaller gets stuck. Use the standard Windows uninstall method instead."
+    echo "\nDocker is still installed."
     exit
 }
 
 # -----[ Main ]----------------------------------------------------------
-if $has_docker43erf; then
+if [ "$has_docker" ]; then
     case $OS in
         centos | rhel)
             remove_centos
@@ -83,7 +78,7 @@ if $has_docker43erf; then
             ;;
     esac
     echo
-    echo "Docker have been successfully removed."
+    echo "Docker has been uninstalled successfully."
 else
-    echo "Docker doesn't exist."
+    echo "Docker is not installed."
 fi

--- a/scripts/docker-uninstall.sh
+++ b/scripts/docker-uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-has_docker=$(command -v docker > /dev/null 2>&1)
+has_docker=$(command -v docker 2> /dev/null 1>&1)
 
 if [ "$(uname)" = "Linux" ]; then
     if [ -n "$WSL_DISTRO_NAME" ]; then

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+:: Check if WSL is installed
+wsl --version >nul 2>&1
+
+if %errorlevel% equ 0 (
+    wsl [ -d ~/.income-generator ] && wsl "${SHELL##*/}" -ilc "igm" || (
+        echo No Income Generator Tool found. Fetching...
+        echo:
+
+        wsl git clone --depth=1 https://github.com/XternA/income-generator.git ~/.income-generator
+        wsl grep -q "igm='(cd ~/.income-generator; sh start.sh)'" ~/."${SHELL##*/}"rc || (
+            wsl echo "alias igm='(cd ~/.income-generator; sh start.sh)'" >> ~/."${SHELL##*/}"rc
+            wsl source ~/."${SHELL##*/}"rc
+        )
+
+        echo:
+        echo Launching...
+        timeout /t 2 /nobreak >nul 2>&1
+        wsl "${SHELL##*/}" -ilc "igm"
+    )
+) else (
+    echo No Windows Subsystem for Linux found on the system. Ensure WSL is available before proceeding.
+)


### PR DESCRIPTION
- Added support for Windows integration
- Added script to allow Windows to run from the command line without needing to first switch to WSL. Can access globally via `igm` provided environment variable is set to execute the `start.bat` script.
- Refactored script logic to support both Unix and Windows WSL.