### PR TITLE
Add Restrictions To Ensure Config Is Complete

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -14,10 +14,10 @@ display_banner() {
     clear
     printf $YELLOW
     echo "=========================================================="
-    echo "#   Dotenv Configure Script                              #"
+    echo "#   Dotenv Configuration Script                          #"
     echo "=========================================================="
-    echo "# Script for updating and configuring the .env file with #"
-    echo "# given input values.                                    #"
+    echo "# Configure and update the configuration file setup      #"
+    echo "# stored within a config file called .env.               #"
     echo "=========================================================="
     printf $NC
 }

--- a/start.sh
+++ b/start.sh
@@ -63,6 +63,22 @@ option_1() {
                         ;;
                     esac
                     display_banner
+
+                    # Check if the separator line exists and get its line number
+                    separator_line=$(grep -n "#--*$" $ENV_FILE | head -n 1)
+                    if [ -n "$separator_line" ]; then
+                        line_number=$(echo "$separator_line" | cut -d ":" -f 1)
+
+                        # Check if there are lines after the separator
+                        if ! tail -n "+$((line_number + 1))" $ENV_FILE | grep -v '^[[:space:]]*$' | grep -q "^"; then
+                            echo "No configrations for applications found. Make sure to complete the configuration setup."
+                            echo "Running setup configuration now..."
+                            sleep 0.6
+                            sh scripts/config.sh
+                            return
+                        fi
+                    fi
+
                     echo $install_type
                     echo
                     docker compose --env-file $ENV_FILE $compose_files pull


### PR DESCRIPTION
When installing applications, if the config file detects that there is no setup for the applications then it will load the setup configurations first.

- Added restrictions so that if trying to run install for the first time will prompt the user to setup the config first.
- Refactored config script language slightly.