### PR TITLE
EarnApp - New Device Registration

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2,7 +2,8 @@
     {
         "name": "EARNAPP",
         "url": "https://bit.ly/4a4XJLF",
-        "description": " If previously installed. Obtain UUID from the dashboard to re-assign. Recommended, otherwise new UUID is generated. Go to dashboard to register device.",
+        "description": " If previously installed. Obtain UUID from the dashboard to re-assign. Recommended, otherwise a new UUID is generated.",
+        "registration": "Register the new device with the following link: https://earnapp.com/r/",
         "properties": [
             "#EARNAPP_DEVICE_UUID"
         ],

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -63,6 +63,7 @@ process_new_entry() {
     if [ "$entry" != "$entry_name" ]; then
         generate_uuid
         echo "A new UUID has been auto-generated for $RED$entry_name$NC: $YELLOW$input$NC\n"
+        [ "$registration" != null ] && echo "${YELLOW}$registration$input${NC}\n"
         echo "Press Enter to continue..."; read -r input < /dev/tty
     else
         input_new_value
@@ -99,6 +100,7 @@ process_entries() {
         url=$(echo "$config_entry" | jq -r '.url')
         description=$(echo "$config_entry" | jq -r '.description' | tr -d '\n')
         description_ext=$(echo "$config_entry" | jq -r '.description_ext' | tr -d '\n')
+        registration=$(echo "$config_entry" | jq -r '.registration' | tr -d '\n')
 
         echo "\n[ $app_name ]"
         [ "$url" != null ] && echo "Go to $BLUE$url$NC to register an account. (CTRL + Click)"


### PR DESCRIPTION
EarnApp has removed the ability to add a new device manually in the dashboard. This addresses the following issue.

**Changes:**
- When generating a new UUID, a link will include the device UUID, allowing for direct device registration via the dynamic link.