### PR TITLE
expose gaga node port

### DIFF
--- a/compose/compose.hosting.yml
+++ b/compose/compose.hosting.yml
@@ -92,6 +92,8 @@ services:
             - TOKEN=$GAGANODE_TOKEN
         profiles:
           - "${GAGANODE:-DISABLED}"
+        ports:
+            - 36060:36060
         dns:
             - 1.1.1.1
             - 8.8.8.8


### PR DESCRIPTION
Seems like that's the port they want, might as well expose it as rewards are affected by it. Works on my machine. Additional firewall/port forwarding may be required, depending on setup.