### PR TITLE
Fix UUID Missing

### DIFF
--- a/scripts/app-config.sh
+++ b/scripts/app-config.sh
@@ -92,7 +92,7 @@ process_entries() {
             if [ "$(echo "$config_entry" | jq -r '.properties | type')" = "array" ]; then
                 for entry in $properties; do
                     entry_name=$(echo "$entry" | sed 's/^"//' | sed 's/"$//' | tr -d "*#&") # Remove surrounding quotes and denoters
-                    denoter=$(echo "$entry" | cut -c1)
+                    denoter=$(echo "${entry%${entry#?}}")
 
                     [ -n "$(grep "^$entry_name=" "$ENV_FILE")" ] && is_update=true
 

--- a/scripts/util/uuid-generator.sh
+++ b/scripts/util/uuid-generator.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 generate_uuid() {
-    local denoter="$1"
-
     if [ "$(uname)" = "Darwin" ]; then
         uuid="$(uuidgen | tr 'A-Z' 'a-z')"
     else


### PR DESCRIPTION
This PR fixes the issue when trying to auto-generate a new UUID for application that requires it and shows empty result when prompted, causing issue of unable to locate the UUID value that is generated.