### PR TITLE
Fix Proxy Tun Not Working

### DIFF
--- a/compose/compose.proxy.yml
+++ b/compose/compose.proxy.yml
@@ -16,7 +16,7 @@ services:
         dns:
             - 1.1.1.1
             - 8.8.8.8
-        volumes:
+        devices:
             - /dev/net/tun:/dev/net/tun
         cpus: $ALT_MIN_CPU_LIMIT
         mem_limit: $RAM_LIMIT

--- a/scripts/util/uuid-generator.sh
+++ b/scripts/util/uuid-generator.sh
@@ -7,7 +7,7 @@ generate_uuid() {
         uuid="$(cat /proc/sys/kernel/random/uuid)"
     fi
 
-    case "$denoter" in
+    case "$1" in
         "#") echo "sdk-node-$(echo "$uuid" | tr -d '-')" ;;
         "*") echo "$uuid" ;;
         "&") echo "$uuid" | tr -d '-' ;;


### PR DESCRIPTION
This PR addresses the recent problem of `tun2socks` proxy tunnel failing due to `Operation not permitted.` error when trying to create tunnel during proxy application installation.