### PR TITLE
Update Watchtower To Be Custom To Income Generator

### DIFF
--- a/compose/compose.hosting.yml
+++ b/compose/compose.hosting.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - RP_EMAIL=${REPOCKET_EMAIL:-}
             - RP_API_KEY=${REPOCKET_API_KEY:-}
@@ -31,6 +32,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - api_key=${PROXYRACK_API_KEY:-}
             - device_name=${DEVICE_ID:-}
@@ -57,6 +59,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - USER_ID=${PROXYLITE_USER_ID:-}
         platform: linux/amd64
@@ -81,6 +84,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - EARNFM_TOKEN=${EARNFM_TOKEN:-}
         profiles:
@@ -104,6 +108,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         cap_add:
             - NET_ADMIN
         command: service --agreed-terms-and-conditions
@@ -132,6 +137,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             BITPING_EMAIL: ${BITPING_EMAIL:-}
             BITPING_PASSWORD: ${BITPING_PASSWORD:-}
@@ -158,6 +164,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - TOKEN=${GAGANODE_TOKEN:-}
         profiles:
@@ -181,6 +188,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         command: >
             -email=${BEARSHARE_EMAIL:-}
             -password=${BEARSHARE_PASSWORD:-}

--- a/compose/compose.local.yml
+++ b/compose/compose.local.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - EARNAPP_UUID=${EARNAPP_DEVICE_UUID:-}
             - EARNAPP_TERM=yes
@@ -34,6 +35,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - CID=${PACKETSTREAM_CID:-}
         profiles:
@@ -57,6 +59,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - CODE=${SPEEDSHARE_AUTH_CODE:-}
             - SPEEDSHARE_UUID=${SPEEDSHARE_UUID:-}
@@ -82,6 +85,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - ID=${SPIDE_MACHINE_ID:-}
         profiles:
@@ -105,6 +109,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - USER_EMAIL=${GRASS_EMAIL:-}
             - USER_PASSWORD=${GRASS_PASSWORD:-}
@@ -129,6 +134,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - NP_COOKIE=${NODEPAY_COOKIE:-}
         profiles:

--- a/compose/compose.proxy.yml
+++ b/compose/compose.proxy.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=proxy
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - LOGLEVEL=info
             - PROXY=${PROXY_URL:-}

--- a/compose/compose.service.yml
+++ b/compose/compose.service.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - EMAIL=${HONEYGAIN_EMAIL:-}
             - PASSWORD=${HONEYGAIN_PASSWORD:-}
@@ -30,6 +31,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - EMAIL=${BEARSHARE_EMAIL:-}
             - PASSWORD=${BEARSHARE_PASSWORD:-}
@@ -54,6 +56,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - EMAIL=${PACKETSHARE_EMAIL:-}
             - PASSWORD=${PACKETSHARE_PASSWORD:-}

--- a/compose/compose.single.yml
+++ b/compose/compose.single.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         command: >
             -tou-accept
             -email ${HONEYGAIN_EMAIL:-}
@@ -32,6 +33,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         command: >
             -accept-tos
             -email=${PAWNS_EMAIL:-}
@@ -59,6 +61,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         command: >
             -accept-tos
             -email=${PACKETSHARE_EMAIL:-}

--- a/compose/compose.unlimited.yml
+++ b/compose/compose.unlimited.yml
@@ -6,6 +6,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         environment:
             - P2P_EMAIL=${P2PROFIT_EMAIL:-}
         platform: linux/amd64
@@ -30,6 +31,7 @@ services:
         hostname: $DEVICE_ID
         labels:
             - project=standard
+            - com.centurylinklabs.watchtower.scope=igm
         command: >
             start accept
             --token ${TRAFFMONETIZER_TOKEN:-}

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -1,6 +1,6 @@
 services:
-    watchtower:
-        container_name: watchtower
+    watchtower-igm:
+        container_name: watchtower-igm
         image: containrrr/watchtower
         restart: always
         labels:
@@ -13,6 +13,7 @@ services:
             --include-restarting
             --revive-stopped
             --interval 9000
+            --scope igm
         dns:
             - 1.1.1.1
             - 8.8.8.8

--- a/scripts/container/watchtower.sh
+++ b/scripts/container/watchtower.sh
@@ -2,7 +2,7 @@
 
 WATCHTOWER_COMPOSE="$COMPOSE_DIR/compose.yml"
 COMMAND="$CONTAINER_COMPOSE $SYSTEM_ENV_FILES -f $WATCHTOWER_COMPOSE up --force-recreate --build -d"
-WATCHTOWER_ALIAS="watchtower"
+WATCHTOWER_ALIAS="watchtower-igm"
 
 modify_watchtower() {
     cp "$WATCHTOWER_COMPOSE" "$WATCHTOWER_COMPOSE.bak" > /dev/null 2>&1


### PR DESCRIPTION
This PR updates the `Watchtower` responsible for auto updating application's to the latest version when available to now be custom to Income Generator.

The purpose of these changes are:
- Avoids conflict with `watchtower` that already exist on the existing host.
- Allows running existing `watchtower` alongside IGM's `watchtower`.
- This `watchtower` is specific for IGM and will only monitor applications belonging to IGM.
- Container name of IGM's watchtower is called `watchtower-igm`.
- Ensuring all applications stays up to date.