### PR TITLE
Fix: Make color output work across more systems

### DIFF
--- a/scripts/app-config.sh
+++ b/scripts/app-config.sh
@@ -7,12 +7,12 @@ trap 'rm -f $FILE_CHANGED' INT
 
 display_banner() {
     clear
-    echo "${GREEN}==========================================================="
-    echo "#     ${NC}Application Credential Setup Manager${GREEN}                #"
+    echo -e "${GREEN}==========================================================="
+    echo -e "#     ${NC}Application Credential Setup Manager${GREEN}                #"
     echo "==========================================================="
-    echo "#  ${NC}Manage, update and configure application credentials.${GREEN}  #"
-    echo "#  ${NC}Credentials are stored locally in a ${RED}.env${NC} config file.${GREEN}  #"
-    echo "===========================================================${NC}"
+    echo -e "#  ${NC}Manage, update and configure application credentials.${GREEN}  #"
+    echo -e "#  ${NC}Credentials are stored locally in a ${RED}.env${NC} config file.${GREEN}  #"
+    echo -e "===========================================================${NC}"
 }
 
 write_entry() {
@@ -38,8 +38,8 @@ process_new_entry() {
     if [ "$entry" != "$entry_name" ]; then
         input="$(generate_uuid $denoter)"
         write_entry
-        echo "A new UUID has been auto-generated for $RED$entry_name$NC: $YELLOW$input$NC\n"
-        [ "$registration" != null ] && echo "${YELLOW}$registration$input${NC}\n"
+        echo -e "A new UUID has been auto-generated for $RED$entry_name$NC: $YELLOW$input$NC\n"
+        [ "$registration" != null ] && echo -e "${YELLOW}$registration$input${NC}\n"
         echo "Press Enter to continue..."; read -r input < /dev/tty
     else
         input_new_value
@@ -64,7 +64,7 @@ process_entries() {
         [ $(echo "$config_entry" | jq -r '.is_enabled') = false ] && continue
 
         display_banner
-        echo "\nConfiguring application ${RED}$entry_count${NC} of ${RED}$num_entries${NC}"
+        echo -e "\nConfiguring application ${RED}$entry_count${NC} of ${RED}$num_entries${NC}"
 
         app_name=$(echo "$config_entry" | jq -r '.name')
         url=$(echo "$config_entry" | jq -r '.url')
@@ -72,10 +72,10 @@ process_entries() {
         description_ext=$(echo "$config_entry" | jq -r '.description_ext' | tr -d '\n')
         registration=$(echo "$config_entry" | jq -r '.registration' | tr -d '\n')
 
-        echo "\n[ ${GREEN}$app_name${NC} ]"
-        [ "$url" != null ] && echo "Go to $BLUE$url$NC to register an account. (CTRL + Click)"
-        [ "$description" != null ] && echo "Description: ${YELLOW}$description${NC}"
-        [ "$description_ext" != null ] && echo "${YELLOW}$description_ext${NC}"
+        echo -e "\n[ ${GREEN}$app_name${NC} ]"
+        [ "$url" != null ] && echo -e "Go to $BLUE$url$NC to register an account. (CTRL + Click)"
+        [ "$description" != null ] && echo -e "Description: ${YELLOW}$description${NC}"
+        [ "$description_ext" != null ] && echo -e "${YELLOW}$description_ext${NC}"
         echo
 
         if [ -z "$(echo "$config_entry" | jq -r '.properties // empty')" ]; then
@@ -111,24 +111,24 @@ process_entries() {
 
     display_banner
     if [ -e "$FILE_CHANGED" ]; then
-        echo "\nDone configuring config file '${RED}$ENV_FILE${NC}'."
+        echo -e "\nDone configuring config file '${RED}$ENV_FILE${NC}'."
     else
-        echo "\nNo changes made to '${RED}$ENV_FILE${NC}'."
+        echo -e "\nNo changes made to '${RED}$ENV_FILE${NC}'."
     fi
     rm -f $FILE_CHANGED
 }
 
 # Main script
 if [ -f "$ENV_FILE" ]; then
-    echo "Credentials will be stored in '${RED}$ENV_FILE${NC}'"
+    echo -e "Credentials will be stored in '${RED}$ENV_FILE${NC}'"
     printf "\nStart the application setup process? (Y/N): "; read -r input
     if [ "$input" = "y" ]; then
         process_entries
     else
-        echo "\nNo changes made to '${RED}$ENV_FILE${NC}'."
+        echo -e "\nNo changes made to '${RED}$ENV_FILE${NC}'."
     fi
 else
-    echo "Dotenv file '${RED}$ENV_FILE${NC}' not found. Creating new one...\n"
+    echo -e "Dotenv file '${RED}$ENV_FILE${NC}' not found. Creating new one...\n"
     sleep 1.4
     touch "$ENV_FILE"
     process_entries

--- a/scripts/app-selection.sh
+++ b/scripts/app-selection.sh
@@ -3,7 +3,7 @@
 display_banner() {
     clear
     echo "Income Generator Application Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 choose_application_type() {
@@ -39,13 +39,13 @@ display_table_choice() {
         display_banner
         app_data=$(cat "$JSON_FILE" | jq -r ".[] | select(has(\"$field_name\")) | \"\(.name) \(.${field_name})\"")
 
-        echo "${RED}Disabled${NC} ${application}s will not be deployed.\n"
+        echo -e "${RED}Disabled${NC} ${application}s will not be deployed.\n"
 
         printf "%-4s %-21s %-8s\n" "No." "$header Name" "Status"
         printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
 
         counter=1
-        echo "$app_data" | awk -v counter="$counter" -v GREEN="$GREEN" -v RED="$RED" -v NC="$NC" '
+        echo -e "$app_data" | awk -v counter="$counter" -v GREEN="$GREEN" -v RED="$RED" -v NC="$NC" '
         {
             if ($2 == "true") {
                 status = GREEN "Enabled" NC
@@ -56,11 +56,11 @@ display_table_choice() {
             counter++
         }'
 
-        echo "\nOptions:"
-        echo "  ${GREEN}e${NC} = ${GREEN}enable all${NC}"
-        echo "  ${RED}d${NC} = ${RED}disable all${NC}"
-        [ ! -z "$switch_type" ] && echo "  ${YELLOW}${shortcut}${NC} = ${YELLOW}select ${switch_type}${NC}"
-        echo "  ${BLUE}0${NC} = ${BLUE}exit${NC}"
+        echo -e "\nOptions:"
+        echo -e "  ${GREEN}e${NC} = ${GREEN}enable all${NC}"
+        echo -e "  ${RED}d${NC} = ${RED}disable all${NC}"
+        [ ! -z "$switch_type" ] && echo -e "  ${YELLOW}${shortcut}${NC} = ${YELLOW}select ${switch_type}${NC}"
+        echo -e "  ${BLUE}0${NC} = ${BLUE}exit${NC}"
 
         printf "\nSelect to ${GREEN}enable${NC} | ${RED}disable${NC} $application (1-%s): " "$(echo "$app_data" | wc -l | xargs)"
         read -r choice
@@ -69,7 +69,7 @@ display_table_choice() {
             [1-9]*)
                 # Enable or disable specific application
                 if ! [ "$choice" -ge 1 ] || ! [ "$choice" -le "$(echo "$app_data" | wc -l)" ]; then
-                    echo "\nInvalid input! Please enter a number between 1 and $(echo "$app_data" | wc -l)."
+                    echo -e "\nInvalid input! Please enter a number between 1 and $(echo "$app_data" | wc -l)."
                     printf "\nPress Enter to continue..."; read input
                 else
                     # Update entry
@@ -109,7 +109,7 @@ display_table_choice() {
                 exit 0
                 ;;
             *)
-                echo "\nInvalid option! Please select a valid option."
+                echo -e "\nInvalid option! Please select a valid option."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -186,7 +186,7 @@ parse_cmd_arg() {
     elif [ "$1" = "--backup" ]; then
         TARGET_DEPLOY_FILE="$TARGET_DEPLOY_FILE.backup"
         export_selection
-        echo "\nBackup current app state successfully."
+        echo -e "\nBackup current app state successfully."
         exit 0
     elif [ "$1" = "--restore" ]; then
         save_state=$([ "$2" = "redeploy" ] && echo true || echo false)
@@ -205,9 +205,9 @@ parse_cmd_arg() {
             [ $save_state = "false" ] && rm -f "$TARGET_DEPLOY_FILE"
             TARGET_DEPLOY_FILE=$tmp
             export_selection
-            echo "\nSuccessfully re-applied app's enabled/disabled state from ${restore_type}."
+            echo -e "\nSuccessfully re-applied app's enabled/disabled state from ${restore_type}."
         else
-            echo "\nNo ${restore_type} found. Nothing to restore from."
+            echo -e "\nNo ${restore_type} found. Nothing to restore from."
         fi
         exit 0
     fi

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -16,7 +16,7 @@ fi
 display_banner() {
     clear
     echo "Backup & Restore Config Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 backup_config() {
@@ -25,8 +25,8 @@ backup_config() {
             display_banner
             options="(1-3)"
 
-            echo "Backup file ${RED}$BACKUP_FILE${NC} already exists.\n"
-            echo "Choose an option:\n"
+            echo -e "Backup file ${RED}$BACKUP_FILE${NC} already exists.\n"
+            echo -e "Choose an option:\n"
             echo "1. View current backup file configuration"
             echo "2. View current in-use configuration"
             echo "3. Replace old backup with the current configurations"
@@ -45,9 +45,9 @@ backup_config() {
 
                     # TODO - Remove in future updates
                     if [ "$IS_OLD_CONFIG" = true ]; then
-                        echo "${YELLOW}---------[ START OF CONFIG ]---------\n${BLUE}"
+                        echo -e "${YELLOW}---------[ START OF CONFIG ]---------\n${BLUE}"
                         tail -n +14 $ENV_FILE
-                        echo "${YELLOW}\n----------[ END OF CONFIG ]----------${NC}"
+                        echo -e "${YELLOW}\n----------[ END OF CONFIG ]----------${NC}"
 
                         printf "\nPress Enter to continue..."; read input
                     else
@@ -97,7 +97,7 @@ backup_config() {
         cp -f "$ENV_FILE" "$BACKUP_FILE"
     fi
 
-    echo "Backup completed. Content has been saved to ${RED}$BACKUP_FILE${NC}."
+    echo -e "Backup completed. Content has been saved to ${RED}$BACKUP_FILE${NC}."
 }
 
 restore_config() {
@@ -123,7 +123,7 @@ restore_config() {
     else
         mv -f $BACKUP_FILE $ENV_FILE
     fi
-    echo "Restore completed. Content has been restored from ${RED}$BACKUP_FILE${NC}."
+    echo -e "Restore completed. Content has been restored from ${RED}$BACKUP_FILE${NC}."
 }
 
 remove_backup() {
@@ -132,7 +132,7 @@ remove_backup() {
         return
     fi
     rm -f $BACKUP_FILE
-    echo "Successfully removed backup config ${RED}$BACKUP_FILE${NC}."
+    echo -e "Successfully removed backup config ${RED}$BACKUP_FILE${NC}."
 }
 
 # Main script
@@ -142,7 +142,7 @@ while true; do
     display_banner
     options="(1-3)"
 
-    echo "What would you like to do?\n"
+    echo -e "What would you like to do?\n"
     echo "1. Backup config file"
     echo "2. Restore config file"
     echo "3. Delete backup file"
@@ -168,7 +168,7 @@ while true; do
             exit 0
             ;;
         *)
-            echo "\nInvalid option. Please select a valid option $options."
+            echo -e "\nInvalid option. Please select a valid option $options."
             ;;
     esac
     printf "\nPress Enter to continue..."; read input

--- a/scripts/check-tool-update.sh
+++ b/scripts/check-tool-update.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
     --update)
-        echo "\nChecking and attempting to get latest updates...\n"
+        echo -e "\nChecking and attempting to get latest updates...\n"
         git fetch; git reset --hard; git pull
         ;;
     *)

--- a/scripts/config-viewer.sh
+++ b/scripts/config-viewer.sh
@@ -13,13 +13,13 @@ else
     COMMENT='\x1b[90m' # Grey
     RESET='\x1b[0m'    # Reset
 
-    echo "${YELLOW}---------[ START OF $TYPE ]---------\n${RED}"
+    echo -e "${YELLOW}---------[ START OF $TYPE ]---------\n${RED}"
     if [ "$TYPE" = "PROXY" ]; then
         cat "$FILE" | sed -e "s/^#.*$/\x1b[90m&\x1b[0m/"
     else
         cat "$FILE" | sed -e "s/^\([^=]*\)=\(.*\)$/${KEY}\1${EQUALS}=${VALUE}\2${RESET}/" -e "s/^##.*/${COMMENT}&${RESET}/"
     fi
-    echo "${YELLOW}\n----------[ END OF $TYPE ]----------${NC}"
+    echo -e "${YELLOW}\n----------[ END OF $TYPE ]----------${NC}"
 fi
 
 printf "\nPress Enter to continue..."; read input

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -60,7 +60,7 @@ install_arch() {
 # macOS
 install_darwin() {
     brew install --cask docker
-    echo "\nLaunching Docker Desktop in order to start the Docker Engine..."
+    echo -e "\nLaunching Docker Desktop in order to start the Docker Engine..."
     echo "Make sure Docker Engine is fully running before proceeding..."
     open -a Docker
 }
@@ -70,11 +70,11 @@ install_wsl() {
     if [ -e "$(which winget.exe 2> /dev/null)" ]; then
         winget.exe install -e --id Docker.DockerDesktop
         $("/mnt/c/Program Files/Docker/Docker/Docker Desktop.exe")
-        echo "\nLaunching Docker Desktop in order to start the Docker Engine..."
+        echo -e "\nLaunching Docker Desktop in order to start the Docker Engine..."
         echo "Make sure Docker Engine is fully running before proceeding..."
     else
         echo "Winget Package Manager is not found. Make sure Winget is installed before trying again."
-        echo "\nDocker is not installed.".
+        echo -e "\nDocker is not installed.".
         exit
     fi
 }
@@ -112,8 +112,8 @@ if [ ! "$HAS_CONTAINER_RUNTIME" ]; then
         sudo usermod -aG docker "$(whoami)"
         newgrp docker
     fi
-    echo "\nDocker has been installed successfully."
-    echo "\nRestart host if docker doesn't start."
+    echo -e "\nDocker has been installed successfully."
+    echo -e "\nRestart host if docker doesn't start."
 else
     echo "Docker is already installed."
 fi

--- a/scripts/docker-uninstall.sh
+++ b/scripts/docker-uninstall.sh
@@ -47,7 +47,7 @@ remove_darwin() {
 
 remove_wsl() {
     echo "Uninstalling Docker via Winget is currently not supported as the uninstaller gets stuck. Use the standard Windows uninstall method instead."
-    echo "\nDocker is still installed."
+    echo -e "\nDocker is still installed."
     exit
 }
 

--- a/scripts/emulation-layer.sh
+++ b/scripts/emulation-layer.sh
@@ -8,9 +8,9 @@ add_cron_job() {
     if ! echo "$current_crontab" | grep -Fxq "$cron"; then
         (echo "$current_crontab"; echo "$cron") | crontab -
         ($command > /dev/null 2>&1)
-        echo "\nQEMU emulation layer added."
+        echo -e "\nQEMU emulation layer added."
     else
-        echo "\nQEMU emulation layer already exist."
+        echo -e "\nQEMU emulation layer already exist."
     fi
 }
 
@@ -18,7 +18,7 @@ remove_cron_job() {
     if echo "$current_crontab" | grep -Fxq "$cron"; then
         new_crontab=$(echo "$current_crontab" | grep -Fv "$cron")
         echo "$new_crontab" | crontab -
-        echo "\nQEMU emulation layer removed."
+        echo -e "\nQEMU emulation layer removed."
     fi
 }
 

--- a/scripts/proxy/proxy-manager.sh
+++ b/scripts/proxy/proxy-manager.sh
@@ -23,7 +23,7 @@ HOST="$(hostname)"
 display_banner() {
     clear
     echo "Income Generator Proxy Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 read_app_data() {
@@ -53,8 +53,8 @@ display_info() {
         echo "No applications selected to install."
         can_install="false"
     else
-        echo "The following proxy applications will be $type.\n"
-        echo "Total Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+        echo -e "The following proxy applications will be $type.\n"
+        echo -e "Total Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
 
         printf "%-4s %-21s\n" "No." "Name"
         printf "%-4s %-21s\n" "---" "--------------------"
@@ -93,8 +93,8 @@ display_proxy_info() {
         *) protocol_name="Unknown" ;;
     esac
 
-    echo "Proxy Address:  ${RED}$host_port${NC}"
-    echo "Proxy Protocol: ${RED}$protocol_name${NC}"
+    echo -e "Proxy Address:  ${RED}$host_port${NC}"
+    echo -e "Proxy Protocol: ${RED}$protocol_name${NC}"
 }
 
 update_app_uuid() {
@@ -154,9 +154,9 @@ install_proxy_instance() {
     cp "$ENV_FILE" "$ENV_FILE.bak"
 
     display_banner
-    echo "Pulling latest image...\n"
+    echo -e "Pulling latest image...\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED $COMPOSE_FILES -f $TUNNEL_COMPOSE_FILE pull
-    echo "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+    echo -e "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
 
     install_count=1
     proxy_entry_pointer=1
@@ -166,9 +166,9 @@ install_proxy_instance() {
             continue # Skip entries not in use.
         fi
 
-        echo "${GREEN}[ ${YELLOW}Installing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
+        echo -e "${GREEN}[ ${YELLOW}Installing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
         display_proxy_info "$proxy_url"
-        echo "PROXY_URL=$proxy_url" > "$ENV_PROXY_FILE"
+        echo -e "PROXY_URL=$proxy_url" > "$ENV_PROXY_FILE"
 
         echo "$APP_DATA" | while read -r name alias is_enabled proxy_uuid; do
             if [ "$alias" = null ]; then
@@ -176,7 +176,7 @@ install_proxy_instance() {
             else
                 app_name=$(printf '%s' "$alias" | tr '[:upper:]' '[:lower:]')
             fi
-            echo " ${GREEN}->${NC} ${app_name}-${install_count}"
+            echo -e " ${GREEN}->${NC} ${app_name}-${install_count}"
 
             for compose_file in $COMPOSE_FILES; do
                 if [ "$compose_file" != "-f" ]; then
@@ -277,13 +277,13 @@ remove_proxy_instance() {
 
     display_banner
     echo "Removing proxy applications..."
-    echo "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+    echo -e "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
 
     install_count=1
     while test "$install_count" -le "$TOTAL_PROXIES"; do
         [ "$(echo "$proxy_url" | cut -c1)" = "#" ] && continue # Skip entries not in use.
 
-        echo "${GREEN}[ ${YELLOW}Removing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
+        echo -e "${GREEN}[ ${YELLOW}Removing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
 
         echo "$APP_DATA" | while read -r name alias is_enabled proxy_uuid; do
             if [ "$alias" = null ]; then
@@ -292,7 +292,7 @@ remove_proxy_instance() {
                 app_name=$(printf '%s' "$alias" | tr '[:upper:]' '[:lower:]')
             fi
             app_name="${app_name}-${install_count}"
-            echo " ${GREEN}->${NC} $app_name"
+            echo -e " ${GREEN}->${NC} $app_name"
             $CONTAINER_ALIAS rm -f "$app_name" > /dev/null 2>&1
         done
 

--- a/scripts/proxy/proxy-menu.sh
+++ b/scripts/proxy/proxy-menu.sh
@@ -7,17 +7,17 @@ HAS_PROXY_APPS="$CONTAINER_ALIAS ps -a -q -f 'label=project=proxy' | head -n 1"
 display_banner() {
     clear
     echo "Income Generator Proxy Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 setup_proxy() {
     display_banner
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
         echo "Proxy application still active."
-        echo "\nRemove existing applications first before editing."
+        echo -e "\nRemove existing applications first before editing."
         printf "\nPress Enter to continue..."; read input
     else
-        echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
+        echo -e "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
         printf "\nPress Enter to continue..."; read input
         nano "$PROXY_FILE"
         [ -f "$PROXY_FILE" ] && [ "$(tail -c 1 "$PROXY_FILE")" != "" ] && echo "" >> "$PROXY_FILE"
@@ -28,7 +28,7 @@ select_proxy_app() {
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
         display_banner
         echo "Proxy application still active."
-        echo "\nRemove existing applications first."
+        echo -e "\nRemove existing applications first."
         printf "\nPress Enter to continue..."; read input
     else
         $APP_SELECTION proxy proxy
@@ -41,7 +41,7 @@ install_proxy_app() {
 
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
         echo "Proxy application still active."
-        echo "\nRemove existing applications first."
+        echo -e "\nRemove existing applications first."
         printf "\nPress Enter to continue..."; read input
     else
         sh "scripts/proxy/proxy-manager.sh" install
@@ -60,7 +60,7 @@ edit_proxy_file() {
 
         if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
             echo "Proxy application still active."
-            echo "\nRemove existing applications first."
+            echo -e "\nRemove existing applications first."
             printf "\nPress Enter to continue..."; read input
             return
         fi
@@ -74,7 +74,7 @@ edit_proxy_file() {
         total_files="$(printf '%s\n' "$uuid_files" | wc -l)"
         options="(1-${total_files})"
 
-        echo "Current applications with multiple UUIDs.\n"
+        echo -e "Current applications with multiple UUIDs.\n"
 
         printf "%-4s %-21s\n" "No." "Name"
         printf "%-4s %-21s\n" "---" "--------------------"
@@ -84,14 +84,14 @@ edit_proxy_file() {
             printf "%-4s %s%-21s%s\n", counter, GREEN, $1, NC
             counter++
         }'
-        echo "\nOption:\n  ${YELLOW}0${NC} = ${YELLOW}exit${NC}"
+        echo -e "\nOption:\n  ${YELLOW}0${NC} = ${YELLOW}exit${NC}"
 
         printf "\nSelect an entry to edit $options: "
         read -r input
 
         case "$input" in
             ''|*[!0-9]*)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 continue
                 ;;
@@ -102,11 +102,11 @@ edit_proxy_file() {
         if [ "$input" -ge 1 ] && [ "$input" -le "$total_files" ]; then
             display_banner
             app="$(set -- $uuid_files; eval echo \${$input})"
-            echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
+            echo -e "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
             printf "\nPress Enter to continue..."; read input
             nano "${PROXY_FOLDER}/${app}.uuid"
         else
-            echo "\nInvalid option. Please select a valid option $options."
+            echo -e "\nInvalid option. Please select a valid option $options."
             printf "\nPress Enter to continue..."; read input
         fi
     done
@@ -129,7 +129,7 @@ manage_uuids() {
             1)
                 display_banner
                 if [ ! -d "$PROXY_FOLDER" ]; then
-                    echo "No multi-UUIDs application entries found.\n"
+                    echo -e "No multi-UUIDs application entries found.\n"
                 else
                     view_proxy_uuids all
                 fi
@@ -142,7 +142,7 @@ manage_uuids() {
 
                     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
                         echo "Proxy application still active."
-                        echo "\nRemove existing applications first."
+                        echo -e "\nRemove existing applications first."
                         printf "\nPress Enter to continue..."; read input
                         break
                     fi
@@ -152,8 +152,8 @@ manage_uuids() {
                         return
                     fi
 
-                    echo "Do you want to clear all application generated multi-UUIDs?\n"
-                    echo "You might want to backup if you wish to re-use the IDs later.\n"
+                    echo -e "Do you want to clear all application generated multi-UUIDs?\n"
+                    echo -e "You might want to backup if you wish to re-use the IDs later.\n"
                     read -p "Do you really want to delete all entries? (Y/N): " yn
 
                     case $yn in
@@ -176,7 +176,7 @@ manage_uuids() {
                 done
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -186,10 +186,10 @@ manage_uuids() {
 view_proxy() {
     display_banner
     if [ ! -e "$PROXY_FILE" ]; then
-        echo "Proxy file doesn't exist.\nSetup proxy entries first."
+        echo -e "Proxy file doesn't exist.\nSetup proxy entries first."
         printf "\nPress Enter to continue..."; read input
     elif [ ! -s "$PROXY_FILE" ]; then
-        echo "Proxy file is empty.\nAdd proxy entries first."
+        echo -e "Proxy file is empty.\nAdd proxy entries first."
         printf "\nPress Enter to continue..."; read input
     else
         $VIEW_CONFIG "$PROXY_FILE" "PROXY"
@@ -204,12 +204,12 @@ reset_proxy() {
     else
         if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
             echo "Proxy application still active."
-            echo "\nRemove existing applications first."
+            echo -e "\nRemove existing applications first."
             printf "\nPress Enter to continue..."; read input
         else
             while true; do
                 display_banner
-                echo "All proxy entries will be removed.\n"
+                echo -e "All proxy entries will be removed.\n"
                 read -p "Do you want to continue? (Y/N): " input
 
                 case $input in
@@ -225,7 +225,7 @@ reset_proxy() {
                     [nN])
                         break ;;
                     *)
-                        echo "\nInvalid option. Please enter 'Y' or 'N'."
+                        echo -e "\nInvalid option. Please enter 'Y' or 'N'."
                         printf "\nPress Enter to continue..."; read input
                         ;;
                 esac
@@ -239,14 +239,14 @@ view_uuids() {
 
     if [ -d "$PROXY_FOLDER_ACTIVE" ]; then
         echo "Multi-UUID applications with instruction need to be registered."
-        echo "Unregisted IDs will not count towards earnings.\n"
+        echo -e "Unregisted IDs will not count towards earnings.\n"
 
-        echo "Deployed applications with in-use unqiue UUIDs are shown here.\n"
+        echo -e "Deployed applications with in-use unqiue UUIDs are shown here.\n"
 
         view_proxy_uuids active
         printf "Press Enter to continue..."; read input
     else
-        echo "Application with multi-UUIDs are auto generated during installtion.\n"
+        echo -e "Application with multi-UUIDs are auto generated during installtion.\n"
         echo "After installation, check here to view UUIDs and further instructions."
         printf "\nPress Enter to continue..."; read input
     fi
@@ -285,7 +285,7 @@ main_menu() {
             8) view_proxy ;;
             9) reset_proxy ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac

--- a/scripts/proxy/proxy-uuid-generator.sh
+++ b/scripts/proxy/proxy-uuid-generator.sh
@@ -37,36 +37,36 @@ view_proxy_uuids() {
             filename="${file##*/}"
             app_name="${filename%%.*}" # Remove extension
 
-            echo "[ ${RED}${app_name}${NC} ]${NC}"
+            echo -e "[ ${RED}${app_name}${NC} ]${NC}"
             counter=0
             while IFS= read -r line; do
-                [ $(( counter % 2 )) -eq 0 ] && echo "${YELLOW}$line" || echo "${BLUE}$line"
+                [ $(( counter % 2 )) -eq 0 ] && echo -e "${YELLOW}$line" || echo -e "${BLUE}$line"
                 counter=$((counter + 1))
             done < "$file"
-            echo "$NC"
+            echo -e "$NC"
         done
         return
     fi
 
-    echo "Active Proxies: ${RED}${TOTAL_PROXIES}${NC}\n"
+    echo -e "Active Proxies: ${RED}${TOTAL_PROXIES}${NC}\n"
 
     if [ "$1" = "active" ]; then
         app_data=$(jq -r '.[] | select(.is_enabled == true and .proxy_uuid != null) | "\(.name) \(.proxy_uuid.description)"' "$JSON_FILE")
 
-        [ -z "$app_data" ] && echo "No active application with multi-UUID currently in use.\n" && return
+        [ -z "$app_data" ] && echo -e "No active application with multi-UUID currently in use.\n" && return
 
         echo "$app_data" | while read -r name description; do
             file="${PROXY_FOLDER_ACTIVE}/${name}.uuid"
 
             [ -f "$file" ] || continue
 
-            echo "[ ${GREEN}${name}${NC} ]${NC}"
-            [ "$description" != null ] && echo "${PINK}$description${NC}\n"
+            echo -e "[ ${GREEN}${name}${NC} ]${NC}"
+            [ "$description" != null ] && echo -e "${PINK}$description${NC}\n"
 
             while IFS= read -r line; do
-                echo " ${GREEN}-> ${YELLOW}$line${NC}"
+                echo -e " ${GREEN}-> ${YELLOW}$line${NC}"
             done < "$file"
-            echo "$NC"
+            echo -e "$NC"
         done
         return
     fi

--- a/scripts/sub-menu/app-manager.sh
+++ b/scripts/sub-menu/app-manager.sh
@@ -34,19 +34,19 @@ display_install_info() {
     if [ "$is_reinstall_state" != "redeploy" ]; then
         total_apps="Total Available:\n ${GREEN}Applications: ${RED}$(jq '. | length' "$JSON_FILE")${NC} | \
                 ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}\n"
-        echo $total_apps
+        echo -e $total_apps
     fi
 
     if [ -z "$has_apps_services" ]; then
         can_install="false"
 
         if [ "$is_reinstall_state" = "redeploy" ]; then
-            echo "No save state to redeploy from.\nInstall normally to save state first."
+            echo -e "No save state to redeploy from.\nInstall normally to save state first."
         else
             echo "No applications/services currently selected to ${install_type}."
         fi
     else
-        echo "The following applications will be ${install_type}.\n"
+        echo -e "The following applications will be ${install_type}.\n"
 
         printf "%-4s %-21s %-8s\n" "No." "Name" "Type"
         printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
@@ -69,13 +69,13 @@ display_install_info() {
     fi
 
     if [ "$is_reinstall_state" != "redeploy" ]; then
-        echo "\nOption:"
-        echo "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
-        echo "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}"
+        echo -e "\nOption:"
+        echo -e "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
+        echo -e "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}"
     else
         if [ "$can_install" = "true" ]; then
-            echo "\nOption:"
-            echo "  ${RED}c${NC} = ${RED}clear redeploy state${NC}"
+            echo -e "\nOption:"
+            echo -e "  ${RED}c${NC} = ${RED}clear redeploy state${NC}"
         fi
     fi
 
@@ -98,13 +98,13 @@ install_applications() {
 
         total_apps="Total Available:\n ${GREEN}Applications: ${RED}$(jq '. | length' "$JSON_FILE")${NC} | \
                 ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}\n"
-        echo $total_apps
+        echo -e $total_apps
 
         if [ -z "$has_apps_services" ]; then
             echo "No applications/services currently selected to install."
             can_install="false"
         else
-            echo "The following applications will be installed.\n"
+            echo -e "The following applications will be installed.\n"
 
             printf "%-4s %-21s %-8s\n" "No." "Name" "Type"
             printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
@@ -126,9 +126,9 @@ install_applications() {
             can_install="true"
         fi
 
-        echo "\nOption:"
-        echo "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
-        echo "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}\n"
+        echo -e "\nOption:"
+        echo -e "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
+        echo -e "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}\n"
 
         if [ "$can_install" = "false" ]; then
             printf "Select an option or press Enter to return: "
@@ -143,7 +143,7 @@ install_applications() {
         [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
         if [ "$1" = "quick_menu" ]; then
-            echo "How would you like to install?\n"
+            echo -e "How would you like to install?\n"
             exit_option="0. Exit"
         else
             exit_option="0. Return to Main Menu"
@@ -214,7 +214,7 @@ install_applications() {
                 break
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -225,13 +225,13 @@ install_applications() {
         display_banner
         if [ ! -s "$ENV_FILE" ]; then
             echo "No configuration for applications found. Configure app credentials first."
-            echo "Running setup configuration now...\n"
+            echo -e "Running setup configuration now...\n"
             sleep 0.6
             $APP_CONFIG
             return
         fi
 
-        echo "$install_type\n"
+        echo -e "$install_type\n"
         [ "$is_selective" = false ] && { $APP_SELECTION --backup > /dev/null 2>&1; $APP_SELECTION --default > /dev/null 2>&1; }
 
         proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
@@ -268,7 +268,7 @@ reinstall_applications() {
                 ;;
             [Yy])
                 display_banner
-                echo "Redeploying last application install state...\n"
+                echo -e "Redeploying last application install state...\n"
 
                 proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
                 [ "$proxy_is_active" ] && $WATCHTOWER modify_only
@@ -288,7 +288,7 @@ reinstall_applications() {
                 ;;
             c)
                 rm -f "$ENV_DEPLOY_FILE.save"
-                echo "\nRedeploy save state has been cleared."
+                echo -e "\nRedeploy save state has been cleared."
                 printf "\nPress Enter to continue..."; read input
                 ;;
             *)
@@ -302,9 +302,9 @@ reinstall_applications() {
 start_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    echo "Starting applications...\n"
+    echo -e "Starting applications...\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $ALL_COMPOSE_FILES start
-    echo "\nAll installed applications started."
+    echo -e "\nAll installed applications started."
     printf "\nPress Enter to continue..."; read input
 }
 
@@ -317,14 +317,14 @@ start_application() {
 stop_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    echo "Stopping applications...\n"
+    echo -e "Stopping applications...\n"
 
     compose_files=$ALL_COMPOSE_FILES
     proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
     [ "$proxy_is_active" ] && compose_files=$APP_COMPOSE_FILES
 
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $compose_files stop
-    echo "\nAll running applications stopped."
+    echo -e "\nAll running applications stopped."
     printf "\nPress Enter to continue..."; read input
 }
 
@@ -338,7 +338,7 @@ remove_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
-    echo "Stopping and removing applications and volumes...\n"
+    echo -e "Stopping and removing applications and volumes...\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $ALL_COMPOSE_FILES down -v
     echo
 
@@ -346,7 +346,7 @@ remove_applications() {
     [ "$proxy_is_active" ] && $WATCHTOWER deploy
 
     $CONTAINER_ALIAS container prune -f
-    echo "\nAll installed applications and volumes removed."
+    echo -e "\nAll installed applications and volumes removed."
     printf "\nPress Enter to continue..."; read input
 }
 
@@ -360,7 +360,7 @@ show_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
-    echo "Installed Containers:\n"
+    echo -e "Installed Containers:\n"
 
     local proxy_number="${2:-}"
     local proxy_project="com.docker.compose.project=${1}-app-${proxy_number}"
@@ -386,11 +386,11 @@ show_applications() {
                 echo "No installed applications."
             else
                 if [ -n "$(has_apps standard)" ]; then
-                    echo "${GREEN}[ ${YELLOW}Standard Applications ${GREEN}]${NC}\n"
+                    echo -e "${GREEN}[ ${YELLOW}Standard Applications ${GREEN}]${NC}\n"
                     show_apps standard
                 fi
                 if [ -n "$(has_apps proxy)" ]; then
-                    echo "\n${GREEN}[ ${YELLOW}Proxy Applications ${GREEN}]${NC}\n"
+                    echo -e "\n${GREEN}[ ${YELLOW}Proxy Applications ${GREEN}]${NC}\n"
                     show_apps proxy
                 fi
             fi
@@ -398,7 +398,7 @@ show_applications() {
         proxy)
             if [ -z "$(has_apps proxy)" ]; then
                 if [ -n "$proxy_number" ]; then
-                    echo "No installed set ${RED}${proxy_number}${NC} proxy applications."
+                    echo -e "No installed set ${RED}${proxy_number}${NC} proxy applications."
                 else
                     echo "No installed proxy applications."
                 fi

--- a/start.sh
+++ b/start.sh
@@ -13,13 +13,13 @@ STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
 display_banner() {
     clear
     echo "Income Generator Application Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 stats() {
     printf "%s\n\n" "$SYS_INFO"
     printf "%s\n" "$STATS"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    echo -e "${GREEN}----------------------------------------${NC}\n"
 }
 
 option_2() {
@@ -39,7 +39,7 @@ option_2() {
         case $option in
             1)
                 display_banner
-                echo "Setting up application configuration...\n"
+                echo -e "Setting up application configuration...\n"
                 $APP_CONFIG
                 ;;
             2)
@@ -48,7 +48,7 @@ option_2() {
                 ;;
             3)
                 display_banner
-                echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
+                echo -e "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
                 printf "\nPress Enter to continue..."; read input
                 nano .env
                 ;;
@@ -62,7 +62,7 @@ option_2() {
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -85,33 +85,33 @@ option_7() {
             1)
                 while true; do
                     display_banner
-                    echo "[ Docker Housekeeping ]\n"
+                    echo -e "[ Docker Housekeeping ]\n"
                     echo "Performing cleanup on orphaned applications and downloaded images."
-                    echo "Orphaned applications currently running won't be cleaned up.\n"
+                    echo -e  "Orphaned applications currently running won't be cleaned up.\n"
                     read -p "Do you want to perform clean up? (Y/N): " yn
 
                     case $yn in
                         [Yy]*)
                             display_banner
-                            echo "Removing orphaned applications, volumes and downloaded images...\n"
+                            echo -e "Removing orphaned applications, volumes and downloaded images...\n"
                             $CONTAINER_ALIAS system prune -a -f --volumes
-                            echo "\nCleanup completed."
-                            printf "\nPress Enter to continue..."; read input
+                            echo -e "\nCleanup completed."
+                            printf -e "\nPress Enter to continue..."; read input
                             break
                             ;;
                         [Nn]*)
                             break
                             ;;
                         *)
-                            echo "\nPlease input yes (Y/y) or no (N/n)."
-                            printf "\nPress Enter to continue..."; read input
+                            echo -e "\nPlease input yes (Y/y) or no (N/n)."
+                            printf -e "\nPress Enter to continue..."; read input
                             ;;
                     esac
                 done
                 ;;
             2)
                 display_banner
-                echo "Installing Docker...\n"
+                echo -e "Installing Docker...\n"
                 sh scripts/$CONTAINER_ALIAS-install.sh
                 sh scripts/container/container-config.sh --register
                 sh scripts/emulation-layer.sh --add
@@ -119,7 +119,7 @@ option_7() {
                 ;;
             3)
                 display_banner
-                echo "Uninstalling Docker...\n"
+                echo -e "Uninstalling Docker...\n"
                 sh scripts/$CONTAINER_ALIAS-uninstall.sh
                 sh scripts/emulation-layer.sh --remove
                 printf "\nPress Enter to continue..."; read input
@@ -140,7 +140,7 @@ option_8() {
         display_banner
         options="(1-5)"
 
-        echo "Pick a new resource limit utilization based on current hardware limits.\n"
+        echo -e "Pick a new resource limit utilization based on current hardware limits.\n"
         printf "%s\n" "$STATS"
         echo
         echo "1. BASE   -->   350MB RAM"
@@ -165,13 +165,13 @@ option_8() {
                 echo
                 $SET_LIMIT "$limit_type"
                 STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
-                echo "\nRedeploy applications for new limits to take effect."
+                echo -e "\nRedeploy applications for new limits to take effect."
                 ;;
             0)
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 ;;
         esac
         printf "\nPress Enter to continue..."; read input
@@ -202,7 +202,7 @@ option_9() {
                     display_banner
                     options="(1-2)"
 
-                    echo "Re-enable, restore saved application state.\n"
+                    echo -e "Re-enable, restore saved application state.\n"
                     echo "1. Re-enable all applications"
                     echo "2. Restore from saved application state"
                     echo "0. Return to Main Menu"
@@ -212,7 +212,7 @@ option_9() {
                     case $choice in
                         1)
                             $APP_SELECTION --default
-                            echo "\nAll applications have been re-enabled."
+                            echo -e "\nAll applications have been re-enabled."
                             printf "\nPress Enter to continue..."; read input
                             ;;
                         2)
@@ -223,7 +223,7 @@ option_9() {
                             break
                             ;;
                         *)
-                            echo "\nInvalid option. Please select a valid option $options."
+                            echo -e "\nInvalid option. Please select a valid option $options."
                             printf "\nPress Enter to continue..."; read input
                             ;;
                     esac
@@ -238,9 +238,9 @@ option_9() {
             4)
                 while true; do
                     display_banner
-                    echo "${RED}WARNING!${NC}\n\nAbout to reset everything back to default."
+                    echo -e "${RED}WARNING!${NC}\n\nAbout to reset everything back to default."
                     echo "This will remove all configured credentials as well."
-                    echo "Disabled apps will be re-enabled for deployment again.\n"
+                    echo -e "Disabled apps will be re-enabled for deployment again.\n"
 
                     read -p "Do you want to backup credentials first? (Y/N): " yn
                     case $yn in
@@ -253,7 +253,7 @@ option_9() {
                             break
                             ;;
                         *)
-                            echo "\nPlease input yes (Y/y) or no (N/n)."
+                            echo -e "\nPlease input yes (Y/y) or no (N/n)."
                             ;;
                     esac
                     printf "\nPress Enter to continue..."; read input
@@ -265,9 +265,9 @@ option_9() {
                 STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
                 $APP_SELECTION --default
 
-                echo "All settings have been reset. Please run ${PINK}Setup Configuration${NC} again."
+                echo -e "All settings have been reset. Please run ${PINK}Setup Configuration${NC} again."
                 echo "Resource limits will need re-applying if previously set."
-                echo "\nWhat settings can be restored?"
+                echo -e "\nWhat settings can be restored?"
                 echo "  - Application credentials if backed up."
                 echo "  - State of applications that's been enabled/disabled for use."
                 printf "\nPress Enter to continue..."; read input
@@ -282,7 +282,7 @@ option_9() {
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -305,7 +305,7 @@ tool_reset() {
                 break
                 ;;
             *)
-                echo "\nPlease input yes (Y/y) or no (N/n)."
+                echo -e "\nPlease input yes (Y/y) or no (N/n)."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -347,7 +347,7 @@ main_menu() {
             8) option_8 ;;
             9) option_9 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                echo -e "\nInvalid option. Please select a valid option $options."
                 printf "\nPress Enter to continue..."; read input
                 ;;
         esac
@@ -361,16 +361,16 @@ $DECRYPT_CRED
 case "$1" in
     -h|--help|help)
         display_banner
-        echo "Quick action menu of common operations.\n"
+        echo -e "Quick action menu of common operations.\n"
         echo "Usage: igm"
         echo "Usage: igm [option]"
         echo "Usage: igm [option] [arg]"
 
-        echo "\n[${BLUE}General${NC}]"
+        echo -e "\n[${BLUE}General${NC}]"
         echo "  igm                      Launch the Income Generator tool."
         echo "  igm help                 Display this help usage guide."
 
-        echo "\n[${BLUE}Manage${NC}]"
+        echo -e "\n[${BLUE}Manage${NC}]"
         echo "  igm start  [name]        Start one or all currently deployed applications."
         echo "  igm stop   [name]        Stop one or all currently deployed running applications."
         echo "  igm remove [name]        Stop and remove one or all currently deployed applications."
@@ -379,7 +379,7 @@ case "$1" in
         echo "  igm redeploy             Redeploy the last installed application state."
         echo "  igm clean                Cleanup orphaned applications, volumes and downloaded images."
 
-        echo "\n[${BLUE}Proxy${NC}]"
+        echo -e "\n[${BLUE}Proxy${NC}]"
         echo "  igm proxy                Launch the proxy tool menu."
         echo "  igm proxy setup          Setup and define list of proxy entries."
         echo "  igm proxy app            Enable or disable proxy applications for deployment."
@@ -388,7 +388,7 @@ case "$1" in
         echo "  igm proxy reset          Clear all proxy entries and remove proxy file."
         echo "  igm proxy id             Show active applications with multi-UUIDs and instructions."
 
-        echo "\n[${BLUE}Configuration${NC}]"
+        echo -e "\n[${BLUE}Configuration${NC}]"
         echo "  igm app|service          Enable or disable applications/services for deployment."
         echo "  igm setup                Setup credentials for applications to be deployed."
         echo "  igm view                 View all configured application credentials."
@@ -457,7 +457,7 @@ case "$1" in
         ;;
     clean)
         display_banner
-        echo "Cleaning up orphaned applications, volumes and images...\n"
+        echo -e "Cleaning up orphaned applications, volumes and images...\n"
         $CONTAINER_ALIAS system prune -a -f --volumes
         ;;
     app|service)


### PR DESCRIPTION
Some systems like Unraid don’t show colors properly when running the script. Instead of colored output, things like \033[1;92m get printed literally.

This happens because echo doesn’t always interpret escape sequences like \033 or \n, depending on the shell (e.g. sh in BusyBox or Dash). I’ve replaced those echo calls with echo -e, so colors and formatting work as expected (i hope i catched all of them, but from testing it looks good on my end now).

This should make the script’s output look correct across more environments.

Before:
![grafik](https://github.com/user-attachments/assets/1d7487a3-cbea-463e-aefc-f85bd4a40fd6)

After:
![grafik](https://github.com/user-attachments/assets/a1cc5424-3641-417a-8381-c13e32c57141)
