### PR TITLE
Platform compatibility | Change Editor | Platform Info

### DIFF
--- a/scripts/app-config.sh
+++ b/scripts/app-config.sh
@@ -7,12 +7,12 @@ trap 'rm -f $FILE_CHANGED' INT
 
 display_banner() {
     clear
-    echo "${GREEN}==========================================================="
-    echo "#     ${NC}Application Credential Setup Manager${GREEN}                #"
-    echo "==========================================================="
-    echo "#  ${NC}Manage, update and configure application credentials.${GREEN}  #"
-    echo "#  ${NC}Credentials are stored locally in a ${RED}.env${NC} config file.${GREEN}  #"
-    echo "===========================================================${NC}"
+    printf "${GREEN}===========================================================\n"
+    printf "#  ${NC}Application Credential Setup Manager${GREEN}                   #\n"
+    printf "===========================================================\n"
+    printf "#  ${NC}Manage, update and configure application credentials.${GREEN}  #\n"
+    printf "#  ${NC}Credentials are stored locally in a ${RED}.env${NC} config file.${GREEN}  #\n"
+    printf "===========================================================${NC}\n"
 }
 
 write_entry() {
@@ -38,9 +38,9 @@ process_new_entry() {
     if [ "$entry" != "$entry_name" ]; then
         input="$(generate_uuid $denoter)"
         write_entry
-        echo "A new UUID has been auto-generated for $RED$entry_name$NC: $YELLOW$input$NC\n"
-        [ "$registration" != null ] && echo "${YELLOW}$registration$input${NC}\n"
-        echo "Press Enter to continue..."; read -r input < /dev/tty
+        printf "A new UUID has been auto-generated for $RED$entry_name$NC: $YELLOW$input$NC\n\n"
+        [ "$registration" != null ] && printf "${YELLOW}$registration$input${NC}\n"
+        printf "\nPress Enter to continue..."; read -r input < /dev/tty
     else
         input_new_value
     fi
@@ -64,7 +64,7 @@ process_entries() {
         [ $(echo "$config_entry" | jq -r '.is_enabled') = false ] && continue
 
         display_banner
-        echo "\nConfiguring application ${RED}$entry_count${NC} of ${RED}$num_entries${NC}"
+        printf "\nConfiguring application ${RED}$entry_count${NC} of ${RED}$num_entries${NC}\n"
 
         app_name=$(echo "$config_entry" | jq -r '.name')
         url=$(echo "$config_entry" | jq -r '.url')
@@ -72,10 +72,10 @@ process_entries() {
         description_ext=$(echo "$config_entry" | jq -r '.description_ext' | tr -d '\n')
         registration=$(echo "$config_entry" | jq -r '.registration' | tr -d '\n')
 
-        echo "\n[ ${GREEN}$app_name${NC} ]"
-        [ "$url" != null ] && echo "Go to $BLUE$url$NC to register an account. (CTRL + Click)"
-        [ "$description" != null ] && echo "Description: ${YELLOW}$description${NC}"
-        [ "$description_ext" != null ] && echo "${YELLOW}$description_ext${NC}"
+        printf "\n[ ${GREEN}$app_name${NC} ]\n"
+        [ "$url" != null ] && printf "Go to $BLUE$url$NC to register an account. (CTRL + Click)\n"
+        [ "$description" != null ] && printf "Description: ${YELLOW}$description${NC}\n"
+        [ "$description_ext" != null ] && printf "${YELLOW}$description_ext${NC}\n"
         echo
 
         if [ -z "$(echo "$config_entry" | jq -r '.properties // empty')" ]; then
@@ -111,24 +111,24 @@ process_entries() {
 
     display_banner
     if [ -e "$FILE_CHANGED" ]; then
-        echo "\nDone configuring config file '${RED}$ENV_FILE${NC}'."
+        printf "\nDone configuring config file '${RED}$ENV_FILE${NC}'.\n"
     else
-        echo "\nNo changes made to '${RED}$ENV_FILE${NC}'."
+        printf "\nNo changes made to '${RED}$ENV_FILE${NC}'.\n"
     fi
     rm -f $FILE_CHANGED
 }
 
 # Main script
 if [ -f "$ENV_FILE" ]; then
-    echo "Credentials will be stored in '${RED}$ENV_FILE${NC}'"
+    printf "Credentials will be stored in '${RED}$ENV_FILE${NC}'\n"
     printf "\nStart the application setup process? (Y/N): "; read -r input
     if [ "$input" = "y" ]; then
         process_entries
     else
-        echo "\nNo changes made to '${RED}$ENV_FILE${NC}'."
+        printf "\nNo changes made to '${RED}$ENV_FILE${NC}'.\n"
     fi
 else
-    echo "Dotenv file '${RED}$ENV_FILE${NC}' not found. Creating new one...\n"
+    printf "Dotenv file '${RED}$ENV_FILE${NC}' not found. Creating new one...\n\n"
     sleep 1.4
     touch "$ENV_FILE"
     process_entries

--- a/scripts/app-selection.sh
+++ b/scripts/app-selection.sh
@@ -2,8 +2,8 @@
 
 display_banner() {
     clear
-    echo "Income Generator Application Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "Income Generator Application Manager\n"
+    printf "${GREEN}------------------------------------------${NC}\n\n"
 }
 
 choose_application_type() {
@@ -39,7 +39,7 @@ display_table_choice() {
         display_banner
         app_data=$(cat "$JSON_FILE" | jq -r ".[] | select(has(\"$field_name\")) | \"\(.name) \(.${field_name})\"")
 
-        echo "${RED}Disabled${NC} ${application}s will not be deployed.\n"
+        printf "${RED}Disabled${NC} ${application}s will not be deployed.\n\n"
 
         printf "%-4s %-21s %-8s\n" "No." "$header Name" "Status"
         printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
@@ -56,11 +56,11 @@ display_table_choice() {
             counter++
         }'
 
-        echo "\nOptions:"
-        echo "  ${GREEN}e${NC} = ${GREEN}enable all${NC}"
-        echo "  ${RED}d${NC} = ${RED}disable all${NC}"
-        [ ! -z "$switch_type" ] && echo "  ${YELLOW}${shortcut}${NC} = ${YELLOW}select ${switch_type}${NC}"
-        echo "  ${BLUE}0${NC} = ${BLUE}exit${NC}"
+        printf "\nOptions:\n"
+        printf "  ${GREEN}e${NC} = ${GREEN}enable all${NC}\n"
+        printf "  ${RED}d${NC} = ${RED}disable all${NC}\n"
+        [ ! -z "$switch_type" ] && printf "  ${YELLOW}${shortcut}${NC} = ${YELLOW}select ${switch_type}${NC}\n"
+        printf "  ${BLUE}0${NC} = ${BLUE}exit${NC}\n"
 
         printf "\nSelect to ${GREEN}enable${NC} | ${RED}disable${NC} $application (1-%s): " "$(echo "$app_data" | wc -l | xargs)"
         read -r choice
@@ -69,8 +69,8 @@ display_table_choice() {
             [1-9]*)
                 # Enable or disable specific application
                 if ! [ "$choice" -ge 1 ] || ! [ "$choice" -le "$(echo "$app_data" | wc -l)" ]; then
-                    echo "\nInvalid input! Please enter a number between 1 and $(echo "$app_data" | wc -l)."
-                    printf "\nPress Enter to continue..."; read input
+                    printf "\nInvalid input! Please enter a number between 1 and $(echo "$app_data" | wc -l).\n"
+                    printf "\nPress Enter to continue..."; read -r input
                 else
                     # Update entry
                     temp_file=$(mktemp)
@@ -93,8 +93,8 @@ display_table_choice() {
                 ;;
             a|s)
                 if [ -z "$switch_type" ]; then
-                    echo "\nInvalid option! Please select a valid option."
-                    printf "\nPress Enter to continue..."; read input
+                    printf "\nInvalid option! Please select a valid option.\n"
+                    printf "\nPress Enter to continue..."; read -r input
                 else
                     if [ "$choice" = "s" ]; then
                         choose_application_type service
@@ -109,8 +109,8 @@ display_table_choice() {
                 exit 0
                 ;;
             *)
-                echo "\nInvalid option! Please select a valid option."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option! Please select a valid option.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -205,9 +205,9 @@ parse_cmd_arg() {
             [ $save_state = "false" ] && rm -f "$TARGET_DEPLOY_FILE"
             TARGET_DEPLOY_FILE=$tmp
             export_selection
-            echo "\nSuccessfully re-applied app's enabled/disabled state from ${restore_type}."
+            printf "\nSuccessfully re-applied app's enabled/disabled state from ${restore_type}.\n"
         else
-            echo "\nNo ${restore_type} found. Nothing to restore from."
+            printf "\nNo ${restore_type} found. Nothing to restore from.\n"
         fi
         exit 0
     fi

--- a/scripts/arch.sh
+++ b/scripts/arch.sh
@@ -16,11 +16,41 @@ case $RAW_ARCH in
         ;;
 esac
 
+if [ -f /etc/os-release ]; then
+  while IFS='=' read -r key val; do
+    val=${val%\"}; val=${val#\"}
+    case "$key" in
+      ID) DISTRO=$val ;;
+      VERSION_CODENAME|UBUNTU_CODENAME) [ -z "$CODENAME" ] && CODENAME=$val ;;
+      VERSION_ID) VERSION=$val ;;
+    esac
+  done < /etc/os-release
+elif [ -f /etc/lsb-release ]; then
+  while IFS='=' read -r key val; do
+    val=${val%\"}; val=${val#\"}
+    case "$key" in
+      DISTRIB_ID) DISTRO=$(echo "$val" | tr A-Z a-z) ;;
+      DISTRIB_CODENAME) CODENAME=$val ;;
+      DISTRIB_RELEASE) VERSION=$val ;;
+    esac
+  done < /etc/lsb-release
+elif [ -f /etc/issue ]; then
+  read -r DISTRO VERSION _ < /etc/issue
+  DISTRO=$(echo "$DISTRO" | tr A-Z a-z)
+  CODENAME=""
+else
+  DISTRO=$(uname -s | tr A-Z a-z)
+  CODENAME=""
+  VERSION=""
+fi
+
 DISPLAY_ARCH="$RAW_ARCH ($ARCH)"
 
 echo "Hostname:         $HOST"
-echo "Platform:         $OS"
-echo "Architecture:     $DISPLAY_ARCH\n"
+echo "Platform:         $OS ($DISTRO)"
+echo "Distro Ver:       $CODENAME $VERSION"
+echo "Architecture:     $DISPLAY_ARCH"
+echo
 
 if [ -f "$ENV_SYSTEM_FILE" ]; then
     $SED_INPLACE "s/^DEVICE_ID=.*/DEVICE_ID=$HOST/" "$ENV_SYSTEM_FILE" || echo "DEVICE_ID=$HOST" >> "$ENV_SYSTEM_FILE"

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -15,8 +15,8 @@ fi
 
 display_banner() {
     clear
-    echo "Backup & Restore Config Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "Backup & Restore Config Manager\n"
+    printf "${GREEN}------------------------------------------${NC}\n\n"
 }
 
 backup_config() {
@@ -25,15 +25,14 @@ backup_config() {
             display_banner
             options="(1-3)"
 
-            echo "Backup file ${RED}$BACKUP_FILE${NC} already exists.\n"
-            echo "Choose an option:\n"
+            printf "Backup file ${RED}$BACKUP_FILE${NC} already exists.\n\n"
+            printf "Choose an option:\n\n"
             echo "1. View current backup file configuration"
             echo "2. View current in-use configuration"
             echo "3. Replace old backup with the current configurations"
             echo "0. Exit"
-            echo
-            read -p "Select an option $options: " option
 
+            printf "\nSelect an option $options: "; read -r option
             case "$option" in
                 1)
                     display_banner
@@ -41,15 +40,15 @@ backup_config() {
                     ;;
                 2)
                     display_banner
-                    echo "Content of current in-use configuration.\n"
+                    printf "Content of current in-use configuration.\n\n"
 
                     # TODO - Remove in future updates
                     if [ "$IS_OLD_CONFIG" = true ]; then
-                        echo "${YELLOW}---------[ START OF CONFIG ]---------\n${BLUE}"
+                        printf "${YELLOW}---------[ START OF CONFIG ]---------\n${BLUE}\n"
                         tail -n +14 $ENV_FILE
-                        echo "${YELLOW}\n----------[ END OF CONFIG ]----------${NC}"
+                        printf "${YELLOW}\n----------[ END OF CONFIG ]----------${NC}\n"
 
-                        printf "\nPress Enter to continue..."; read input
+                        printf "\nPress Enter to continue..."; read -r input
                     else
                         $VIEW_CONFIG
                     fi
@@ -66,7 +65,7 @@ backup_config() {
                 *)
                     echo
                     echo "Invalid option. Please select a valid option $options."
-                    printf "\nPress Enter to continue..."; read input
+                    printf "\nPress Enter to continue..."; read -r input
                     ;;
             esac
         done
@@ -97,7 +96,7 @@ backup_config() {
         cp -f "$ENV_FILE" "$BACKUP_FILE"
     fi
 
-    echo "Backup completed. Content has been saved to ${RED}$BACKUP_FILE${NC}."
+    printf "Backup completed. Content has been saved to ${RED}$BACKUP_FILE${NC}.\n"
 }
 
 restore_config() {
@@ -123,7 +122,7 @@ restore_config() {
     else
         mv -f $BACKUP_FILE $ENV_FILE
     fi
-    echo "Restore completed. Content has been restored from ${RED}$BACKUP_FILE${NC}."
+    printf "Restore completed. Content has been restored from ${RED}$BACKUP_FILE${NC}.\n"
 }
 
 remove_backup() {
@@ -132,7 +131,7 @@ remove_backup() {
         return
     fi
     rm -f $BACKUP_FILE
-    echo "Successfully removed backup config ${RED}$BACKUP_FILE${NC}."
+    printf "Successfully removed backup config ${RED}$BACKUP_FILE${NC}.\n"
 }
 
 # Main script
@@ -142,13 +141,13 @@ while true; do
     display_banner
     options="(1-3)"
 
-    echo "What would you like to do?\n"
+    printf "What would you like to do?\n\n"
     echo "1. Backup config file"
     echo "2. Restore config file"
     echo "3. Delete backup file"
     echo "0. Exit"
     echo
-    read -p "Select an option $options: " option
+    printf "Select an option $options: "; read -r option
 
     case "$option" in
         1)
@@ -168,8 +167,8 @@ while true; do
             exit 0
             ;;
         *)
-            echo "\nInvalid option. Please select a valid option $options."
+            printf "\nInvalid option. Please select a valid option $options.\n"
             ;;
     esac
-    printf "\nPress Enter to continue..."; read input
+    printf "\nPress Enter to continue..."; read -r input
 done

--- a/scripts/config-viewer.sh
+++ b/scripts/config-viewer.sh
@@ -13,13 +13,13 @@ else
     COMMENT='\x1b[90m' # Grey
     RESET='\x1b[0m'    # Reset
 
-    echo "${YELLOW}---------[ START OF $TYPE ]---------\n${RED}"
+    printf "${YELLOW}---------[ START OF $TYPE ]---------\n${RED}\n"
     if [ "$TYPE" = "PROXY" ]; then
         cat "$FILE" | sed -e "s/^#.*$/\x1b[90m&\x1b[0m/"
     else
         cat "$FILE" | sed -e "s/^\([^=]*\)=\(.*\)$/${KEY}\1${EQUALS}=${VALUE}\2${RESET}/" -e "s/^##.*/${COMMENT}&${RESET}/"
     fi
-    echo "${YELLOW}\n----------[ END OF $TYPE ]----------${NC}"
+    printf "${YELLOW}\n----------[ END OF $TYPE ]----------${NC}\n"
 fi
 
-printf "\nPress Enter to continue..."; read input
+printf "\nPress Enter to continue..."; read -r input

--- a/scripts/container/container-config.sh
+++ b/scripts/container/container-config.sh
@@ -2,7 +2,7 @@
 
 print_no_runtime() {
     printf "No $CONTAINER_ALIAS runtime installed.\nPlease install container runtime from tool menu.\n"
-    printf "\nPress Enter to continue..."; read input
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 register_compose() {

--- a/scripts/editor.sh
+++ b/scripts/editor.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set_if_not_defined() {
+    [ -z "$EDITOR" ] && EDITOR=nano
+}
+
+sync_editor() {
+    EDITOR="$(sed -n '/^EDITOR=/ { s/^EDITOR=//; p; q }' $ENV_SYSTEM_FILE)"
+    [ -z "$EDITOR" ] && echo "EDITOR=nano" >> "$ENV_SYSTEM_FILE"
+}
+
+set_editor() {
+    local editors="nvim vim vi nano"
+
+    available_editors=""
+    for editor in $editors; do
+        command -v "$editor" >/dev/null 2>&1 && available_editors="$available_editors $editor"
+    done
+
+    if [ -z "$available_editors" ]; then
+        printf "No suitable editors found. Install ${RED}nano${NC} editor first.\n\n"
+        printf "Press Enter to continue..."; read -r input
+        return
+    fi
+
+    sync_editor
+
+    while true; do
+        display_banner
+
+        printf "Choose your default editor:\n\n"
+        printf "Current editor: ${RED}$EDITOR${NC}\n\n"
+
+        i=1
+        for editor in $available_editors; do
+            echo "$i) $editor"
+            i=$((i + 1))
+        done
+        echo "0) No change"
+
+        options="(1-$((i - 1)))"
+
+        printf "\nSelect an option $options: "; read -r choice
+        case $choice in
+            [1-9])
+                i=1
+                for editor in $available_editors; do
+                    if [ "$i" = "$choice" ]; then
+                        $SED_INPLACE "s/^EDITOR=.*/EDITOR=$editor/" "$ENV_SYSTEM_FILE"
+
+                        printf "\nEditor is now set to: ${GREEN}$editor${NC}\n"
+                        printf "\nPress Enter to continue..."; read -r input
+
+                        sync_editor
+                        break
+                    fi
+                    i=$((i + 1))
+                done
+                ;;
+            0) return ;;
+            *)
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
+                ;;
+        esac
+    done
+}
+
+get_editor_description() {
+    case "$EDITOR" in
+        nvim|vim|vi) printf "Using ${RED}$EDITOR${NC} editor, don't forget to save changes after edit.\n" ;;
+        nano) printf "After editing, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n" ;;
+        *) break ;;
+    esac
+}
+
+run_editor() {
+    set_if_not_defined
+    "$EDITOR" "$@"
+}
+
+sync_editor

--- a/scripts/proxy/proxy-manager.sh
+++ b/scripts/proxy/proxy-manager.sh
@@ -22,8 +22,8 @@ HOST="$(hostname)"
 
 display_banner() {
     clear
-    echo "Income Generator Proxy Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "Income Generator Proxy Manager\n"
+    printf "${GREEN}------------------------------------------${NC}\n\n"
 }
 
 read_app_data() {
@@ -54,7 +54,7 @@ display_info() {
         can_install="false"
     else
         echo "The following proxy applications will be $type.\n"
-        echo "Total Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+        printf "Total Proxies: ${RED}$TOTAL_PROXIES${NC}\n\n"
 
         printf "%-4s %-21s\n" "No." "Name"
         printf "%-4s %-21s\n" "---" "--------------------"
@@ -66,7 +66,7 @@ display_info() {
         }'
     fi
 
-    [ "$is_install" = "true" ] && echo "\nOption:\n  ${RED}a = select applications${NC}"
+    [ "$is_install" = "true" ] && printf "\nOption:\n  ${RED}a = select applications${NC}\n"
 
     if [ "$can_install" = "false" ]; then
         printf "\nSelect applications or press Enter to return: "
@@ -93,8 +93,8 @@ display_proxy_info() {
         *) protocol_name="Unknown" ;;
     esac
 
-    echo "Proxy Address:  ${RED}$host_port${NC}"
-    echo "Proxy Protocol: ${RED}$protocol_name${NC}"
+    printf "Proxy Address:  ${RED}$host_port${NC}\n"
+    printf "Proxy Protocol: ${RED}$protocol_name${NC}\n"
 }
 
 update_app_uuid() {
@@ -154,9 +154,9 @@ install_proxy_instance() {
     cp "$ENV_FILE" "$ENV_FILE.bak"
 
     display_banner
-    echo "Pulling latest image...\n"
+    printf "Pulling latest image...\n\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED $COMPOSE_FILES -f $TUNNEL_COMPOSE_FILE pull
-    echo "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+    printf "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n\n"
 
     install_count=1
     proxy_entry_pointer=1
@@ -166,7 +166,7 @@ install_proxy_instance() {
             continue # Skip entries not in use.
         fi
 
-        echo "${GREEN}[ ${YELLOW}Installing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
+        printf "${GREEN}[ ${YELLOW}Installing Proxy Set ${RED}${install_count} ${GREEN}]${NC}\n"
         display_proxy_info "$proxy_url"
         echo "PROXY_URL=$proxy_url" > "$ENV_PROXY_FILE"
 
@@ -176,7 +176,7 @@ install_proxy_instance() {
             else
                 app_name=$(printf '%s' "$alias" | tr '[:upper:]' '[:lower:]')
             fi
-            echo " ${GREEN}->${NC} ${app_name}-${install_count}"
+            printf " ${GREEN}->${NC} ${app_name}-${install_count}\n"
 
             for compose_file in $COMPOSE_FILES; do
                 if [ "$compose_file" != "-f" ]; then
@@ -246,7 +246,7 @@ install_proxy_instance() {
     rm -f "${TUNNEL_COMPOSE_FILE}.bk" "$ENV_PROXY_FILE"
 
     echo "Proxy application install complete."
-    printf "\nPress Enter to continue..."; read input
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 remove_proxy_instance() {
@@ -254,7 +254,7 @@ remove_proxy_instance() {
     if [ -z $(eval "$has_proxy_apps") ]; then
         display_banner
         echo "No installed proxy applications."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
         return
     fi
 
@@ -277,13 +277,13 @@ remove_proxy_instance() {
 
     display_banner
     echo "Removing proxy applications..."
-    echo "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n"
+    printf "\nTotal Proxies: ${RED}$TOTAL_PROXIES${NC}\n\n"
 
     install_count=1
     while test "$install_count" -le "$TOTAL_PROXIES"; do
         [ "$(echo "$proxy_url" | cut -c1)" = "#" ] && continue # Skip entries not in use.
 
-        echo "${GREEN}[ ${YELLOW}Removing Proxy Set ${RED}${install_count} ${GREEN}]${NC}"
+        printf "${GREEN}[ ${YELLOW}Removing Proxy Set ${RED}${install_count} ${GREEN}]${NC}\n"
 
         echo "$APP_DATA" | while read -r name alias is_enabled proxy_uuid; do
             if [ "$alias" = null ]; then
@@ -292,7 +292,7 @@ remove_proxy_instance() {
                 app_name=$(printf '%s' "$alias" | tr '[:upper:]' '[:lower:]')
             fi
             app_name="${app_name}-${install_count}"
-            echo " ${GREEN}->${NC} $app_name"
+            printf " ${GREEN}->${NC} $app_name\n"
             $CONTAINER_ALIAS rm -f "$app_name" > /dev/null 2>&1
         done
 
@@ -306,17 +306,17 @@ remove_proxy_instance() {
     rm -rf $PROXY_FOLDER_ACTIVE
 
     echo "Proxy application uninstall complete."
-    printf "\nPress Enter to continue..."; read input
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 check_proxy_file() {
     if [ ! -e "$PROXY_FILE" ]; then
         echo "Proxy file doesn't exist.\nSetup proxy entries first."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
         exit 0
     elif [ ! -s "$PROXY_FILE" ]; then
         echo "Proxy file is empty. Add entries first."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
         exit 0
     fi
 
@@ -336,7 +336,7 @@ check_proxy_file() {
     ' "$PROXY_FILE"
 
     if [ $? -eq 1 ]; then
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
         exit 1
     fi
 }

--- a/scripts/proxy/proxy-menu.sh
+++ b/scripts/proxy/proxy-menu.sh
@@ -6,19 +6,18 @@ HAS_PROXY_APPS="$CONTAINER_ALIAS ps -a -q -f 'label=project=proxy' | head -n 1"
 
 display_banner() {
     clear
-    echo "Income Generator Proxy Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "Income Generator Proxy Manager\n"
+    printf "${GREEN}------------------------------------------${NC}\n\n"
 }
 
 setup_proxy() {
     display_banner
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
-        echo "Proxy application still active."
-        echo "\nRemove existing applications first before editing."
-        printf "\nPress Enter to continue..."; read input
+        printf "Proxy application still active.\nRemove existing applications first before editing.\n"
+        printf "\nPress Enter to continue..."; read -r input
     else
-        echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
-        printf "\nPress Enter to continue..."; read input
+        printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+        printf "\nPress Enter to continue..."; read -r input
         nano "$PROXY_FILE"
         [ -f "$PROXY_FILE" ] && [ "$(tail -c 1 "$PROXY_FILE")" != "" ] && echo "" >> "$PROXY_FILE"
     fi
@@ -27,9 +26,8 @@ setup_proxy() {
 select_proxy_app() {
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
         display_banner
-        echo "Proxy application still active."
-        echo "\nRemove existing applications first."
-        printf "\nPress Enter to continue..."; read input
+        printf "Proxy application still active.\nRemove existing applications first.\n"
+        printf "\nPress Enter to continue..."; read -r input
     else
         $APP_SELECTION proxy proxy
     fi
@@ -40,9 +38,8 @@ install_proxy_app() {
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
-        echo "Proxy application still active."
-        echo "\nRemove existing applications first."
-        printf "\nPress Enter to continue..."; read input
+        printf "Proxy application still active.\nRemove existing applications first.\n"
+        printf "\nPress Enter to continue..."; read -r input
     else
         sh "scripts/proxy/proxy-manager.sh" install
     fi
@@ -59,14 +56,13 @@ edit_proxy_file() {
         display_banner
 
         if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
-            echo "Proxy application still active."
-            echo "\nRemove existing applications first."
-            printf "\nPress Enter to continue..."; read input
+            printf "Proxy application still active.\nRemove existing applications first.\n"
+            printf "\nPress Enter to continue..."; read -r input
             return
         fi
         if [ ! -d "$PROXY_FOLDER" ]; then
             echo "No multi-UUIDs application entries found."
-            printf "\nPress Enter to continue..."; read input
+            printf "\nPress Enter to continue..."; read -r input
             return
         fi
 
@@ -74,7 +70,7 @@ edit_proxy_file() {
         total_files="$(printf '%s\n' "$uuid_files" | wc -l)"
         options="(1-${total_files})"
 
-        echo "Current applications with multiple UUIDs.\n"
+        printf "Current applications with multiple UUIDs.\n\n"
 
         printf "%-4s %-21s\n" "No." "Name"
         printf "%-4s %-21s\n" "---" "--------------------"
@@ -84,15 +80,13 @@ edit_proxy_file() {
             printf "%-4s %s%-21s%s\n", counter, GREEN, $1, NC
             counter++
         }'
-        echo "\nOption:\n  ${YELLOW}0${NC} = ${YELLOW}exit${NC}"
+        printf "\nOption:\n  ${YELLOW}0${NC} = ${YELLOW}exit${NC}\n"
 
-        printf "\nSelect an entry to edit $options: "
-        read -r input
-
+        printf "\nSelect an entry to edit $options: "; read -r input
         case "$input" in
             ''|*[!0-9]*)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 continue
                 ;;
         esac
@@ -102,12 +96,12 @@ edit_proxy_file() {
         if [ "$input" -ge 1 ] && [ "$input" -le "$total_files" ]; then
             display_banner
             app="$(set -- $uuid_files; eval echo \${$input})"
-            echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
-            printf "\nPress Enter to continue..."; read input
+            printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+            printf "\nPress Enter to continue..."; read -r input
             nano "${PROXY_FOLDER}/${app}.uuid"
         else
-            echo "\nInvalid option. Please select a valid option $options."
-            printf "\nPress Enter to continue..."; read input
+            printf "\nInvalid option. Please select a valid option $options.\n"
+            printf "\nPress Enter to continue..."; read -r input
         fi
     done
 }
@@ -122,18 +116,18 @@ manage_uuids() {
         echo "3. Clear generated UUIDs"
         echo "0. Return to Main Menu"
         echo
-        read -p "Select an option $options: " choice
 
+        printf "Select an option $options: "; read -r choice
         case $choice in
             0) break ;;
             1)
                 display_banner
                 if [ ! -d "$PROXY_FOLDER" ]; then
-                    echo "No multi-UUIDs application entries found.\n"
+                    printf "No multi-UUIDs application entries found.\n\n"
                 else
                     view_proxy_uuids all
                 fi
-                printf "Press Enter to continue..."; read input
+                printf "Press Enter to continue..."; read -r input
                 ;;
             2) edit_proxy_file ;;
             3)
@@ -141,27 +135,26 @@ manage_uuids() {
                     display_banner
 
                     if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
-                        echo "Proxy application still active."
-                        echo "\nRemove existing applications first."
-                        printf "\nPress Enter to continue..."; read input
+                        printf "Proxy application still active.\nRemove existing applications first.\n"
+                        printf "\nPress Enter to continue..."; read -r input
                         break
                     fi
                     if [ ! -d "$PROXY_FOLDER" ]; then
                         echo "No multi-UUIDs application entries found."
-                        printf "\nPress Enter to continue..."; read input
+                        printf "\nPress Enter to continue..."; read -r input
                         return
                     fi
 
-                    echo "Do you want to clear all application generated multi-UUIDs?\n"
-                    echo "You might want to backup if you wish to re-use the IDs later.\n"
-                    read -p "Do you really want to delete all entries? (Y/N): " yn
+                    printf "Do you want to clear all application generated multi-UUIDs?\n\n"
+                    printf "You might want to backup if you wish to re-use the IDs later.\n\n"
+                    printf "Do you really want to delete all entries? (Y/N): "; read -r yn
 
                     case $yn in
                         [Yy]*)
                             display_banner
                             rm -rf "$PROXY_FOLDER"
                             echo "All application generated UUIDs have been removed."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nPress Enter to continue..."; read -r input
                             break
                             ;;
                         [Nn]*)
@@ -170,14 +163,14 @@ manage_uuids() {
                         *)
                             display_banner
                             echo "Please enter yes (Y/y) or no (N/n)."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nPress Enter to continue..."; read -r input
                             ;;
                     esac
                 done
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -187,10 +180,10 @@ view_proxy() {
     display_banner
     if [ ! -e "$PROXY_FILE" ]; then
         echo "Proxy file doesn't exist.\nSetup proxy entries first."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     elif [ ! -s "$PROXY_FILE" ]; then
         echo "Proxy file is empty.\nAdd proxy entries first."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     else
         $VIEW_CONFIG "$PROXY_FILE" "PROXY"
     fi
@@ -200,17 +193,16 @@ reset_proxy() {
     display_banner
     if [ ! -e "$PROXY_FILE" ]; then
         echo "Proxy file doesn't exist."
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     else
         if [ ! -z $(eval "$HAS_PROXY_APPS") ]; then
-            echo "Proxy application still active."
-            echo "\nRemove existing applications first."
-            printf "\nPress Enter to continue..."; read input
+            printf "Proxy application still active.\nRemove existing applications first.\n"
+            printf "\nPress Enter to continue..."; read -r input
         else
             while true; do
                 display_banner
-                echo "All proxy entries will be removed.\n"
-                read -p "Do you want to continue? (Y/N): " input
+                printf "All proxy entries will be removed.\n\n"
+                printf "Do you want to continue? (Y/N): "; read -r input
 
                 case $input in
                     "")
@@ -219,14 +211,14 @@ reset_proxy() {
                         display_banner
                         echo "All proxy entries removed."
                         rm -f "$PROXY_FILE"
-                        printf "\nPress Enter to continue..."; read input
+                        printf "\nPress Enter to continue..."; read -r input
                         break
                         ;;
                     [nN])
                         break ;;
                     *)
-                        echo "\nInvalid option. Please enter 'Y' or 'N'."
-                        printf "\nPress Enter to continue..."; read input
+                        printf "\nInvalid option. Please enter 'Y' or 'N'.\n"
+                        printf "\nPress Enter to continue..."; read -r input
                         ;;
                 esac
             done
@@ -238,17 +230,16 @@ view_uuids() {
     display_banner
 
     if [ -d "$PROXY_FOLDER_ACTIVE" ]; then
-        echo "Multi-UUID applications with instruction need to be registered."
-        echo "Unregisted IDs will not count towards earnings.\n"
-
-        echo "Deployed applications with in-use unqiue UUIDs are shown here.\n"
+        printf "Multi-UUID applications with instruction need to be registered.\n"
+        printf "Unregisted IDs will not count towards earnings.\n\n"
+        printf "Deployed applications with in-use unqiue UUIDs are shown here.\n\n"
 
         view_proxy_uuids active
-        printf "Press Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     else
-        echo "Application with multi-UUIDs are auto generated during installtion.\n"
-        echo "After installation, check here to view UUIDs and further instructions."
-        printf "\nPress Enter to continue..."; read input
+        printf "Application with multi-UUIDs are auto generated during installtion.\n\n"
+        printf "After installation, check here to view UUIDs and further instructions.\n"
+        printf "\nPress Enter to continue..."; read -r input
     fi
 }
 
@@ -257,7 +248,7 @@ main_menu() {
         display_banner
 
         TOTAL_PROXIES=$([ -e "$PROXY_FILE" ] && awk 'BEGIN {count=0} /^[^#]/ && NF {count++} END {print count}' "$PROXY_FILE" || echo 0)
-        echo "Available Proxies: ${RED}${TOTAL_PROXIES}${NC}\n"
+        printf "Available Proxies: ${RED}${TOTAL_PROXIES}${NC}\n\n"
 
         options="(1-9)"
         echo "1. Setup Proxies"
@@ -271,7 +262,7 @@ main_menu() {
         echo "9. Reset Proxies"
         echo "0. Quit"
         echo
-        read -p "Select an option $options: " choice
+        printf "Select an option $options: "; read -r choice
 
         case $choice in
             0) display_banner Proxy; echo "Quitting..."; sleep 0.62; clear; break ;;
@@ -285,8 +276,8 @@ main_menu() {
             8) view_proxy ;;
             9) reset_proxy ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done

--- a/scripts/proxy/proxy-menu.sh
+++ b/scripts/proxy/proxy-menu.sh
@@ -16,9 +16,9 @@ setup_proxy() {
         printf "Proxy application still active.\nRemove existing applications first before editing.\n"
         printf "\nPress Enter to continue..."; read -r input
     else
-        printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+        get_editor_description
         printf "\nPress Enter to continue..."; read -r input
-        nano "$PROXY_FILE"
+        run_editor "$PROXY_FILE"
         [ -f "$PROXY_FILE" ] && [ "$(tail -c 1 "$PROXY_FILE")" != "" ] && echo "" >> "$PROXY_FILE"
     fi
 }
@@ -96,9 +96,10 @@ edit_proxy_file() {
         if [ "$input" -ge 1 ] && [ "$input" -le "$total_files" ]; then
             display_banner
             app="$(set -- $uuid_files; eval echo \${$input})"
-            printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+
+            get_editor_description
             printf "\nPress Enter to continue..."; read -r input
-            nano "${PROXY_FOLDER}/${app}.uuid"
+            run_editor "${PROXY_FOLDER}/${app}.uuid"
         else
             printf "\nInvalid option. Please select a valid option $options.\n"
             printf "\nPress Enter to continue..."; read -r input

--- a/scripts/sub-menu/app-manager.sh
+++ b/scripts/sub-menu/app-manager.sh
@@ -33,20 +33,20 @@ display_install_info() {
 
     if [ "$is_reinstall_state" != "redeploy" ]; then
         total_apps="Total Available:\n ${GREEN}Applications: ${RED}$(jq '. | length' "$JSON_FILE")${NC} | \
-                ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}\n"
-        echo $total_apps
+                ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}"
+        printf "$total_apps\n\n"
     fi
 
     if [ -z "$has_apps_services" ]; then
         can_install="false"
 
         if [ "$is_reinstall_state" = "redeploy" ]; then
-            echo "No save state to redeploy from.\nInstall normally to save state first."
+            printf "No save state to redeploy from.\nInstall normally to save state first.\n"
         else
-            echo "No applications/services currently selected to ${install_type}."
+            printf "No applications/services currently selected to ${install_type}.\n"
         fi
     else
-        echo "The following applications will be ${install_type}.\n"
+        printf "The following applications will be ${install_type}.\n\n"
 
         printf "%-4s %-21s %-8s\n" "No." "Name" "Type"
         printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
@@ -68,14 +68,13 @@ display_install_info() {
         can_install="true"
     fi
 
+    printf "\nOption:\n"
     if [ "$is_reinstall_state" != "redeploy" ]; then
-        echo "\nOption:"
-        echo "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
-        echo "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}"
+        printf "  ${GREEN}a${NC} = ${GREEN}select applications${NC}\n"
+        printf "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}\n"
     else
         if [ "$can_install" = "true" ]; then
-            echo "\nOption:"
-            echo "  ${RED}c${NC} = ${RED}clear redeploy state${NC}"
+            printf "  ${RED}c${NC} = ${RED}clear redeploy state${NC}\n"
         fi
     fi
 
@@ -88,7 +87,7 @@ display_install_info() {
     else
         printf "\nDo you want to proceed? (Y/N): "
     fi
-    read input
+    read -r input
 }
 
 install_applications() {
@@ -97,14 +96,14 @@ install_applications() {
         has_apps_services=$(echo "$app_data" | awk '{if ($2 == "true" || $3 == "true") {print "true"; exit}}')
 
         total_apps="Total Available:\n ${GREEN}Applications: ${RED}$(jq '. | length' "$JSON_FILE")${NC} | \
-                ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}\n"
-        echo $total_apps
+                ${YELLOW}Services: ${RED}$(jq '[.[] | select(has("service_enabled"))] | length' "$JSON_FILE")${NC}"
+        printf "$total_apps\n\n"
 
         if [ -z "$has_apps_services" ]; then
             echo "No applications/services currently selected to install."
             can_install="false"
         else
-            echo "The following applications will be installed.\n"
+            printf "The following applications will be installed.\n\n"
 
             printf "%-4s %-21s %-8s\n" "No." "Name" "Type"
             printf "%-4s %-21s %-8s\n" "---" "--------------------" "--------"
@@ -126,16 +125,16 @@ install_applications() {
             can_install="true"
         fi
 
-        echo "\nOption:"
-        echo "  ${GREEN}a${NC} = ${GREEN}select applications${NC}"
-        echo "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}\n"
+        printf "\nOption:\n"
+        printf "  ${GREEN}a${NC} = ${GREEN}select applications${NC}\n"
+        printf "  ${YELLOW}s${NC} = ${YELLOW}select services${NC}\n\n"
 
         if [ "$can_install" = "false" ]; then
             printf "Select an option or press Enter to return: "
         else
             printf "Do you want to proceed? (Y/N): "
         fi
-        read input
+        read -r input
     }
 
     while true; do
@@ -143,7 +142,7 @@ install_applications() {
         [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
         if [ "$1" = "quick_menu" ]; then
-            echo "How would you like to install?\n"
+            printf "How would you like to install?\n\n"
             exit_option="0. Exit"
         else
             exit_option="0. Return to Main Menu"
@@ -157,10 +156,8 @@ install_applications() {
         echo "3. Only VPS/Hosting applications"
         echo "4. All service applications"
         echo "$exit_option"
-        echo
-        printf "Select an option %s: " "$options"
-        read option
 
+        printf "\nSelect an option $options: "; read -r option
         case "$option" in
             1)
                 while true; do
@@ -177,14 +174,14 @@ install_applications() {
                                 is_selective=true
                                 break
                             fi
-                            printf "\nInvalid option.\n\nPress Enter to continue..."; read input
+                            printf "\nInvalid option.\n\nPress Enter to continue..."; read -r input
                             ;;
                         [Nn])
                             if [ "$can_install" = "true" ]; then
                                 compose_files=""
                                 break
                             fi
-                            printf "\nInvalid option.\n\nPress Enter to continue..."; read input
+                            printf "\nInvalid option.\n\nPress Enter to continue..."; read -r input
                             ;;
                         a)
                             $APP_SELECTION
@@ -193,7 +190,7 @@ install_applications() {
                             $APP_SELECTION service
                             ;;
                         *)
-                            printf "\nInvalid option.\n\nPress Enter to continue..."; read input
+                            printf "\nInvalid option.\n\nPress Enter to continue..."; read -r input
                             ;;
                     esac
                 done
@@ -214,8 +211,8 @@ install_applications() {
                 break
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
 
@@ -224,19 +221,19 @@ install_applications() {
 
         display_banner
         if [ ! -s "$ENV_FILE" ]; then
-            echo "No configuration for applications found. Configure app credentials first."
-            echo "Running setup configuration now...\n"
+            printf "No configuration for applications found. Configure app credentials first.\n"
+            printf "Running setup configuration now...\n\n"
             sleep 0.6
             $APP_CONFIG
             return
         fi
 
-        echo "$install_type\n"
+        printf "$install_type\n\n"
         [ "$is_selective" = false ] && { $APP_SELECTION --backup > /dev/null 2>&1; $APP_SELECTION --default > /dev/null 2>&1; }
 
         proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
         [ "$proxy_is_active" ] && $WATCHTOWER modify_only
-        
+
         $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED $compose_files pull
         echo
         $CONTAINER_ALIAS container prune -f
@@ -246,7 +243,7 @@ install_applications() {
         $APP_SELECTION --save > /dev/null 2>&1
         $WATCHTOWER restore_only
 
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     done
 }
 
@@ -268,7 +265,7 @@ reinstall_applications() {
                 ;;
             [Yy])
                 display_banner
-                echo "Redeploying last application install state...\n"
+                printf "Redeploying last application install state...\n\n"
 
                 proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
                 [ "$proxy_is_active" ] && $WATCHTOWER modify_only
@@ -280,7 +277,7 @@ reinstall_applications() {
                 $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED $ALL_COMPOSE_FILES up --force-recreate --build -d
                 [ "$proxy_is_active" ] && $WATCHTOWER restore_only
 
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 break
                 ;;
             [Nn])
@@ -288,11 +285,11 @@ reinstall_applications() {
                 ;;
             c)
                 rm -f "$ENV_DEPLOY_FILE.save"
-                echo "\nRedeploy save state has been cleared."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nRedeploy save state has been cleared.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             *)
-                printf "\nInvalid option.\n\nPress Enter to continue..."; read input
+                printf "\nInvalid option.\n\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -302,10 +299,10 @@ reinstall_applications() {
 start_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    echo "Starting applications...\n"
+    printf "Starting applications...\n\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $ALL_COMPOSE_FILES start
-    echo "\nAll installed applications started."
-    printf "\nPress Enter to continue..."; read input
+    printf "\nAll installed applications started.\n"
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 start_application() {
@@ -317,20 +314,20 @@ start_application() {
 stop_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    echo "Stopping applications...\n"
+    printf "Stopping applications...\n\n"
 
     compose_files=$ALL_COMPOSE_FILES
     proxy_is_active="$($CONTAINER_ALIAS ps -a -q -f "label=project=proxy" | head -n 1)"
     [ "$proxy_is_active" ] && compose_files=$APP_COMPOSE_FILES
 
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $compose_files stop
-    echo "\nAll running applications stopped."
-    printf "\nPress Enter to continue..."; read input
+    printf "\nAll running applications stopped.\n"
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 stop_application() {
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    printf "Stopping application "
+    printf "Stopping application"
     $CONTAINER_ALIAS stop -t 6 "$1"
 }
 
@@ -338,7 +335,7 @@ remove_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
-    echo "Stopping and removing applications and volumes...\n"
+    printf "Stopping and removing applications and volumes...\n\n"
     $CONTAINER_COMPOSE $LOADED_ENV_FILES --profile ENABLED --profile DISABLED $ALL_COMPOSE_FILES down -v
     echo
 
@@ -346,13 +343,13 @@ remove_applications() {
     [ "$proxy_is_active" ] && $WATCHTOWER deploy
 
     $CONTAINER_ALIAS container prune -f
-    echo "\nAll installed applications and volumes removed."
-    printf "\nPress Enter to continue..."; read input
+    printf "\nAll installed applications and volumes removed.\n"
+    printf "\nPress Enter to continue..."; read -r input
 }
 
 remove_application() {
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
-    printf "Removing application "
+    printf "Removing application"
     $CONTAINER_ALIAS rm -f -v "$1"
 }
 
@@ -360,7 +357,7 @@ show_applications() {
     display_banner
     [ ! "$HAS_CONTAINER_RUNTIME" ] && print_no_runtime && return
 
-    echo "Installed Containers:\n"
+    printf "Installed Containers:\n\n"
 
     local proxy_number="${2:-}"
     local proxy_project="com.docker.compose.project=${1}-app-${proxy_number}"
@@ -386,11 +383,11 @@ show_applications() {
                 echo "No installed applications."
             else
                 if [ -n "$(has_apps standard)" ]; then
-                    echo "${GREEN}[ ${YELLOW}Standard Applications ${GREEN}]${NC}\n"
+                    printf "${GREEN}[ ${YELLOW}Standard Applications ${GREEN}]${NC}\n\n"
                     show_apps standard
                 fi
                 if [ -n "$(has_apps proxy)" ]; then
-                    echo "\n${GREEN}[ ${YELLOW}Proxy Applications ${GREEN}]${NC}\n"
+                    printf "\n${GREEN}[ ${YELLOW}Proxy Applications ${GREEN}]${NC}\n\n"
                     show_apps proxy
                 fi
             fi
@@ -398,7 +395,7 @@ show_applications() {
         proxy)
             if [ -z "$(has_apps proxy)" ]; then
                 if [ -n "$proxy_number" ]; then
-                    echo "No installed set ${RED}${proxy_number}${NC} proxy applications."
+                    printf "No installed set ${RED}${proxy_number}${NC} proxy applications.\n"
                 else
                     echo "No installed proxy applications."
                 fi
@@ -417,5 +414,5 @@ show_applications() {
             echo "igm: '$1' is not a valid command. See 'igm help'."
             ;;
     esac
-    printf "\nPress Enter to continue..."; read input
+    printf "\nPress Enter to continue..."; read -r input
 }

--- a/start.sh
+++ b/start.sh
@@ -12,14 +12,15 @@ STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
 
 display_banner() {
     clear
-    echo "Income Generator Application Manager"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "Income Generator Application Manager\n"
+    printf "${GREEN}------------------------------------------${NC}\n"
+    [ ! "$1" = "--no_line" ] && echo
 }
 
 stats() {
     printf "%s\n\n" "$SYS_INFO"
     printf "%s\n" "$STATS"
-    echo "${GREEN}----------------------------------------${NC}\n"
+    printf "${GREEN}------------------------------------------${NC}\n\n"
 }
 
 option_2() {
@@ -34,12 +35,12 @@ option_2() {
         echo "5. Backup & restore config"
         echo "0. Return to Main Menu"
         echo
-        read -p "Select an option $options: " option
+        printf "Select an option $options: "; read -r option
 
         case $option in
             1)
                 display_banner
-                echo "Setting up application configuration...\n"
+                printf "Setting up application configuration...\n"
                 $APP_CONFIG
                 ;;
             2)
@@ -48,8 +49,8 @@ option_2() {
                 ;;
             3)
                 display_banner
-                echo "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes."
-                printf "\nPress Enter to continue..."; read input
+                printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 nano .env
                 ;;
             4)
@@ -62,8 +63,8 @@ option_2() {
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -79,57 +80,56 @@ option_7() {
         echo "3. Uninstall Docker"
         echo "0. Return to Main Menu"
         echo
-        read -p "Select an option $options: " option
+        printf "Select an option $options: "; read -r option
 
         case $option in
             1)
                 while true; do
                     display_banner
-                    echo "[ Docker Housekeeping ]\n"
-                    echo "Performing cleanup on orphaned applications and downloaded images."
-                    echo "Orphaned applications currently running won't be cleaned up.\n"
-                    read -p "Do you want to perform clean up? (Y/N): " yn
+                    printf "About to clean up orphaned applications and downloaded images.\n"
+                    printf "Running orphaned applications won't be cleaned up unless stopped.\n\n"
+                    printf "Do you want to perform clean up? (Y/N): "; read -r yn
 
                     case $yn in
                         [Yy]*)
                             display_banner
-                            echo "Removing orphaned applications, volumes and downloaded images...\n"
+                            printf "Removing orphaned applications, volumes and downloaded images...\n\n"
                             $CONTAINER_ALIAS system prune -a -f --volumes
-                            echo "\nCleanup completed."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nCleanup completed.\n"
+                            printf "\nPress Enter to continue..."; read -r input
                             break
                             ;;
                         [Nn]*)
                             break
                             ;;
                         *)
-                            echo "\nPlease input yes (Y/y) or no (N/n)."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nPlease input yes (Y/y) or no (N/n).\n"
+                            printf "\nPress Enter to continue..."; read -r input
                             ;;
                     esac
                 done
                 ;;
             2)
                 display_banner
-                echo "Installing Docker...\n"
+                printf "Installing Docker...\n\n"
                 sh scripts/$CONTAINER_ALIAS-install.sh
                 sh scripts/container/container-config.sh --register
                 sh scripts/emulation-layer.sh --add
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             3)
                 display_banner
-                echo "Uninstalling Docker...\n"
+                printf "Uninstalling Docker...\n\n"
                 sh scripts/$CONTAINER_ALIAS-uninstall.sh
                 sh scripts/emulation-layer.sh --remove
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             0)
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -140,7 +140,7 @@ option_8() {
         display_banner
         options="(1-5)"
 
-        echo "Pick a new resource limit utilization based on current hardware limits.\n"
+        printf "Pick a new resource limit utilization based on current hardware limits.\n\n"
         printf "%s\n" "$STATS"
         echo
         echo "1. BASE   -->   350MB RAM"
@@ -150,7 +150,7 @@ option_8() {
         echo "5. MAX    -->   50% Total RAM"
         [ "$1" = "quick_menu" ] && echo "0. Exit" || echo "0. Return to Main Menu"
         echo
-        read -p "Select an option $options: " option
+        printf "Select an option $options: "; read -r option
 
         case $option in
             1|2|3|4|5)
@@ -165,16 +165,16 @@ option_8() {
                 echo
                 $SET_LIMIT "$limit_type"
                 STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
-                echo "\nRedeploy applications for new limits to take effect."
+                printf "\nRedeploy applications for new limits to take effect.\n"
                 ;;
             0)
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
+                printf "\nInvalid option. Please select a valid option $options.\n"
                 ;;
         esac
-        printf "\nPress Enter to continue..."; read input
+        printf "\nPress Enter to continue..."; read -r input
     done
 }
 
@@ -191,7 +191,7 @@ option_9() {
         echo "5. Check and get update"
         echo "0. Return to Main Menu"
         echo
-        read -p "Select an option $options: " option
+        read -r -p "Select an option $options: " option
 
         case $option in
             1)
@@ -202,29 +202,29 @@ option_9() {
                     display_banner
                     options="(1-2)"
 
-                    echo "Re-enable, restore saved application state.\n"
+                    printf "Re-enable, restore saved application state.\n\n"
                     echo "1. Re-enable all applications"
                     echo "2. Restore from saved application state"
                     echo "0. Return to Main Menu"
                     echo
-                    read -p "Select an option $options: " choice
+                    printf "Select an option $options: "; read -r choice
 
                     case $choice in
                         1)
                             $APP_SELECTION --default
-                            echo "\nAll applications have been re-enabled."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nAll applications have been re-enabled.\n"
+                            printf "\nPress Enter to continue..."; read -r input
                             ;;
                         2)
                             $APP_SELECTION --restore
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nPress Enter to continue..."; read -r input
                             ;;
                         0)
                             break
                             ;;
                         *)
-                            echo "\nInvalid option. Please select a valid option $options."
-                            printf "\nPress Enter to continue..."; read input
+                            printf "\nInvalid option. Please select a valid option $options.\n"
+                            printf "\nPress Enter to continue..."; read -r input
                             ;;
                     esac
                 done
@@ -233,16 +233,16 @@ option_9() {
                 echo
                 $SET_LIMIT low
                 STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             4)
                 while true; do
                     display_banner
-                    echo "${RED}WARNING!${NC}\n\nAbout to reset everything back to default."
-                    echo "This will remove all configured credentials as well."
-                    echo "Disabled apps will be re-enabled for deployment again.\n"
+                    printf "${RED}WARNING!${NC}\n\nAbout to reset everything back to default.\n"
+                    printf "This will remove all configured credentials as well.\n"
+                    printf "Disabled apps will be re-enabled for deployment again.\n"
 
-                    read -p "Do you want to backup credentials first? (Y/N): " yn
+                    printf "\nDo you want to backup credentials first? (Y/N): "; read -r yn
                     case $yn in
                         [Yy]*)
                             $BACKUP_RESTORE
@@ -253,10 +253,10 @@ option_9() {
                             break
                             ;;
                         *)
-                            echo "\nPlease input yes (Y/y) or no (N/n)."
+                            printf "\nPlease input yes (Y/y) or no (N/n).\n"
                             ;;
                     esac
-                    printf "\nPress Enter to continue..."; read input
+                    printf "\nPress Enter to continue..."; read -r input
                 done
 
                 display_banner
@@ -265,25 +265,25 @@ option_9() {
                 STATS="$(sh scripts/limits.sh "$($SET_LIMIT | awk '{print $NF}')")"
                 $APP_SELECTION --default
 
-                echo "All settings have been reset. Please run ${PINK}Setup Configuration${NC} again."
-                echo "Resource limits will need re-applying if previously set."
-                echo "\nWhat settings can be restored?"
-                echo "  - Application credentials if backed up."
-                echo "  - State of applications that's been enabled/disabled for use."
-                printf "\nPress Enter to continue..."; read input
+                printf "All settings have been reset. Please run ${PINK}Setup Configuration${NC} again.\n"
+                printf "Resource limits will need re-applying if previously set.\n"
+                printf "\nWhat settings can be restored?\n"
+                printf "  - Application credentials if backed up.\n"
+                printf "  - State of applications that's been enabled/disabled for use.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             5)
                 $UPDATE_CHECKER --update
                 $APP_SELECTION --import
                 unset NEW_UPDATE
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
             0)
                 break  # Return to the main menu
                 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -292,21 +292,21 @@ option_9() {
 tool_reset() {
     while true; do
         display_banner
-        read -p "Do you want to reset IGM system settings? (Y/N): " yn
+        printf "Do you want to reset IGM system settings? (Y/N): "; read -r yn
         case $yn in
             [Yy]*)
                 display_banner
                 rm -rf .env.system
                 echo "IGM system setting has been reset."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPress Enter to continue..."; read -r input
                 break
                 ;;
             ''|[Nn]*)
                 break
                 ;;
             *)
-                echo "\nPlease input yes (Y/y) or no (N/n)."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nPlease input yes (Y/y) or no (N/n).\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -316,9 +316,9 @@ main_menu() {
     NEW_UPDATE=$($UPDATE_CHECKER)
 
     while true; do
-        display_banner
+        display_banner --no_line
         stats
-        [ -n "$NEW_UPDATE" ] && echo "$NEW_UPDATE\n"
+        [ -n "$NEW_UPDATE" ] && printf "$NEW_UPDATE\n"
 
         options="(1-9)"
 
@@ -333,7 +333,7 @@ main_menu() {
         echo "9. Manage Tool"
         echo "0. Quit"
         echo
-        read -p "Select an option $options: " choice
+        printf "Select an option $options: "; read -r choice
 
         case $choice in
             0) display_banner; echo "Quitting..."; sleep 0.62; clear; break ;;
@@ -347,8 +347,8 @@ main_menu() {
             8) option_8 ;;
             9) option_9 ;;
             *)
-                echo "\nInvalid option. Please select a valid option $options."
-                printf "\nPress Enter to continue..."; read input
+                printf "\nInvalid option. Please select a valid option $options.\n"
+                printf "\nPress Enter to continue..."; read -r input
                 ;;
         esac
     done
@@ -361,16 +361,14 @@ $DECRYPT_CRED
 case "$1" in
     -h|--help|help)
         display_banner
-        echo "Quick action menu of common operations.\n"
-        echo "Usage: igm"
-        echo "Usage: igm [option]"
-        echo "Usage: igm [option] [arg]"
+        printf "Quick action menu of common operations.\n\n"
+        echo "Usage: igm | igm [option] | igm [option] [arg]"
 
-        echo "\n[${BLUE}General${NC}]"
+        printf "\n[${BLUE}General${NC}]\n"
         echo "  igm                      Launch the Income Generator tool."
         echo "  igm help                 Display this help usage guide."
 
-        echo "\n[${BLUE}Manage${NC}]"
+        printf "\n[${BLUE}Manage${NC}]\n"
         echo "  igm start  [name]        Start one or all currently deployed applications."
         echo "  igm stop   [name]        Stop one or all currently deployed running applications."
         echo "  igm remove [name]        Stop and remove one or all currently deployed applications."
@@ -379,7 +377,7 @@ case "$1" in
         echo "  igm redeploy             Redeploy the last installed application state."
         echo "  igm clean                Cleanup orphaned applications, volumes and downloaded images."
 
-        echo "\n[${BLUE}Proxy${NC}]"
+        printf "\n[${BLUE}Proxy${NC}]\n"
         echo "  igm proxy                Launch the proxy tool menu."
         echo "  igm proxy setup          Setup and define list of proxy entries."
         echo "  igm proxy app            Enable or disable proxy applications for deployment."
@@ -388,7 +386,7 @@ case "$1" in
         echo "  igm proxy reset          Clear all proxy entries and remove proxy file."
         echo "  igm proxy id             Show active applications with multi-UUIDs and instructions."
 
-        echo "\n[${BLUE}Configuration${NC}]"
+        printf "\n[${BLUE}Configuration${NC}]\n"
         echo "  igm app|service          Enable or disable applications/services for deployment."
         echo "  igm setup                Setup credentials for applications to be deployed."
         echo "  igm view                 View all configured application credentials."
@@ -457,7 +455,7 @@ case "$1" in
         ;;
     clean)
         display_banner
-        echo "Cleaning up orphaned applications, volumes and images...\n"
+        printf "Cleaning up orphaned applications, volumes and images...\n\n"
         $CONTAINER_ALIAS system prune -a -f --volumes
         ;;
     app|service)

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,7 @@
 . scripts/shared-component.sh
 sh scripts/init.sh
 
+. scripts/editor.sh
 . scripts/container/container-config.sh
 . scripts/sub-menu/app-manager.sh
 . scripts/arch-image-tag.sh
@@ -49,9 +50,9 @@ option_2() {
                 ;;
             3)
                 display_banner
-                printf "After making changes, press '${BLUE}CTRL + X${NC}' and press '${BLUE}Y${NC}' to save changes.\n"
+                get_editor_description
                 printf "\nPress Enter to continue..."; read -r input
-                nano .env
+                run_editor $ENV_FILE
                 ;;
             4)
                 $APP_SELECTION
@@ -178,20 +179,20 @@ option_8() {
     done
 }
 
-option_9() {
+manage_tool() {
     while true; do
         display_banner
 
-        options="(1-5)"
-
+        options="(1-6)"
         echo "1. Backup & restore config"
         echo "2. Manage application state"
         echo "3. Reset resource limit"
         echo "4. Reset all back to default"
         echo "5. Check and get update"
+        echo "6. Change editor tool"
         echo "0. Return to Main Menu"
         echo
-        read -r -p "Select an option $options: " option
+        printf "Select an option $options: "; read -r option
 
         case $option in
             1)
@@ -278,6 +279,10 @@ option_9() {
                 unset NEW_UPDATE
                 printf "\nPress Enter to continue..."; read -r input
                 ;;
+            6)
+                display_banner
+                set_editor
+                ;;
             0)
                 break  # Return to the main menu
                 ;;
@@ -345,7 +350,7 @@ main_menu() {
             6) show_applications ;;
             7) option_7 ;;
             8) option_8 ;;
-            9) option_9 ;;
+            9) manage_tool ;;
             *)
                 printf "\nInvalid option. Please select a valid option $options.\n"
                 printf "\nPress Enter to continue..."; read -r input
@@ -362,7 +367,7 @@ case "$1" in
     -h|--help|help)
         display_banner
         printf "Quick action menu of common operations.\n\n"
-        echo "Usage: igm | igm [option] | igm [option] [arg]"
+        echo "Usage: igm ${BLUE}|${NC} igm [option] ${BLUE}|${NC} igm [option] [arg]"
 
         printf "\n[${BLUE}General${NC}]\n"
         echo "  igm                      Launch the Income Generator tool."
@@ -392,6 +397,7 @@ case "$1" in
         echo "  igm view                 View all configured application credentials."
         echo "  igm edit                 Edit configured credentials and config file directly."
         echo "  igm limit                Set the application resource limits."
+        echo "  igm editor               Change the default editor tool to use."
         echo
         ;;
     "")
@@ -475,11 +481,16 @@ case "$1" in
         clear
         ;;
     edit)
-        nano $ENV_FILE
+        run_editor $ENV_FILE
         clear
         ;;
     limit)
         option_8 quick_menu
+        clear
+        ;;
+    editor)
+        display_banner
+        set_editor
         clear
         ;;
     *)


### PR DESCRIPTION
What's Changed:

- Fix compatibility issue with platforms like Unraid ( BusyBox, Dash, Ash etc.) having issue interpret escape sequences like `\033` or `\n` which displays colour  information on screen. Replaced the use of `echo` to `printf` which is universally compatible for sections that displays complex text.
- Added extra platform information such as distribution and version number to IGM UI which will now show more detail about the environment host.
- Added ability to now change the default editor `nano` tool to the following of choice - `nvim` `vim` `vi` `nano`. 
  - Accessed via `IGM > Manage Tool > Change editor tool`
  - Resetting the IGM tool will revert the editor back to `nano`.
- Added CLI command `igm editor` for quick-access to the editor UI to change editor choice.

Run `igm help` to show all the CLI commands.