### PR TITLE
Fix proxy issue for overlapping folder dir

### DIFF
--- a/compose/compose.hosting.yml
+++ b/compose/compose.hosting.yml
@@ -120,7 +120,7 @@ services:
             - 1.1.1.1
             - 8.8.8.8
         volumes:
-            - $DATA_DIR/mysterium-node:/var/lib/mysterium-node
+            - $DATA_DIR/mysterium:/var/lib/mysterium-node
         cpus: $CPU_LIMIT
         mem_limit: $RAM_LIMIT
         mem_reservation: $RAM_RESERVE

--- a/scripts/proxy/proxy-manager.sh
+++ b/scripts/proxy/proxy-manager.sh
@@ -223,6 +223,9 @@ install_proxy_instance() {
 
                     # Update proxy network and depends on
                     $SED_INPLACE "s/\(${PROXY_APP_NAME}-\)[0-9]*/\1${install_count}/g" "$compose_file"
+
+                    # Update volume dir
+                    $SED_INPLACE "s#\(\$DATA_DIR/\)$app_name\(-[^:/]*\)\?:#\1$new_app_name:#" "$compose_file"
                 fi
             done
 


### PR DESCRIPTION
This branch fixes the issue with proxy applications which has created directories and overlaps with the same name.

The fix is specifically for the application `Mysterium`. Users will need to manually go to the data directory and update the mysterium folder name.

* The old mysterium folder is called `mysterium-node` which needs to be changed to `mysterium`.

- **Linux :** Location is `/data/mysterium`.
- **Windows:** Go into `WSL` and then locate `/data/mysterium`.
- **macOS:** Location is `/usr/local/data/mysterium`.

For proxy version it would have been previously sharing `mysterium-node` folder. Going forward there will be dedicated folders corresponding to the number of proxy entries, so `mysterium-1, mysterium-2` etc. and so shouldn't need to update the folder name as it would have never existed until now.