### PR TITLE
Switch to IGM Exclusive Honeygain Pot Image

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -25,7 +25,9 @@
         "is_enabled": true,
         "service_enabled": true,
         "service_tag": {
-            "arm32": "arm32v7"
+            "amd64": "igm",
+            "arm64": "igm",
+            "arm32": "igm"
         },
         "install_limit": 10
     },


### PR DESCRIPTION
## Switch to IGM-Exclusive Honeygain Pot Image

Replaces the standard Honeygain Pot image with the new IGM-exclusive optimised version.

| Variant                   | Image Size | Platforms               |
|:--------------------------|:-----------|:------------------------|
| Honeygain Pot (IGM)       | 3.98MB     | amd64, arm64, armv7     |
| Honeygain Pot (Standard)  | 153MB      | amd64, arm64            |
| Honeygain Pot (arm32v7)   | 209MB      | armv7                   |  

### Changelog

**Benefits**

- 97.4% smaller - 3.98MB vs 153MB
- Faster execution - Compiled binary with aggressive optimisations
- Multi-platform support - Optimised image supported for platforms: `amd64`, `arm64`, `armv7`
- IGM-exclusive - Licensed specifically for Income Generator use
- Functionally identical - Same features and behaviour as standard version

**Impact**

- Faster setup and startup time (smaller pull size)
- Reduced disk space usage
- Better performance on resource-constrained devices (Raspberry Pi, etc.)
- No configuration changes needed - drop-in replacement