### PR TITLE
Switch PacketStream to In-house

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -91,14 +91,7 @@
         "properties": [
             "PACKETSTREAM_CID"
         ],
-        "is_enabled": true,
-        "platform_override": {
-            "amd64": [
-                "arm64",
-                "armv7l",
-                "armv6l"
-            ]
-        }
+        "is_enabled": true
     },
     {
         "name": "PROXYRACK",

--- a/compose/compose.local.yml
+++ b/compose/compose.local.yml
@@ -27,10 +27,9 @@ services:
 
     packetstream:
         container_name: packetstream
-        image: packetstream/psclient
+        image: ghcr.io/xterna/packetstream
         restart: always
         hostname: $DEVICE_ID
-        platform: ${PACKETSTREAM_PLATFORM:-}
         labels:
             - project=standard
             - com.centurylinklabs.watchtower.scope=igm


### PR DESCRIPTION
This PR switches out the PacketStream registry to in-house which fixes the wrong arch type used for `arm64` hosts and for compatibility sake, having to override all platforms to use `amd64` version which is now completely removed.