### PR TITLE
Switch Proxyrack to optimised version with multi-arch support

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -103,6 +103,12 @@
         ],
         "uuid_type": 2,
         "is_enabled": true,
+        "platform_override": {
+            "amd64": [
+                "armv7l",
+                "armv6l"
+            ]
+        },
         "proxy_uuid": {
             "name_type": "UUID",
             "description": "Register device ID in app dashboard's 'Devices' section."

--- a/compose/compose.hosting.yml
+++ b/compose/compose.hosting.yml
@@ -30,6 +30,7 @@ services:
         image: ghcr.io/xterna/proxyrack
         restart: always
         hostname: $DEVICE_ID
+        platform: ${PROXYRACK_PLATFORM:-}
         labels:
             - project=standard
             - com.centurylinklabs.watchtower.scope=igm

--- a/compose/compose.hosting.yml
+++ b/compose/compose.hosting.yml
@@ -27,7 +27,7 @@ services:
 
     proxyrack:
         container_name: proxyrack
-        image: proxyrack/pop
+        image: ghcr.io/xterna/proxyrack
         restart: always
         hostname: $DEVICE_ID
         labels:
@@ -37,7 +37,7 @@ services:
             - UUID=${PROXYRACK_UUID:-}
             - API_KEY=${PROXYRACK_API_KEY:-}
             - DEVICE_NAME=${DEVICE_ID:-}
-        platform: linux/amd64
+            - LICENSE=IGM
         profiles:
             - ${PROXYRACK:-DISABLED}
         dns:


### PR DESCRIPTION
Switching Proxyrack to in-house optimised version which supports multi-arch and lighter image base:

- x86_64 (amd64)
- ARM 64 (arm64)